### PR TITLE
Fix issue when there are no models to reset

### DIFF
--- a/bin/rails-response-dumper
+++ b/bin/rails-response-dumper
@@ -27,7 +27,7 @@ class ResponseDumper
   end
 
   def self.reset_models!
-    @reset_models.each do |model|
+    reset_models.each do |model|
       model.connection.exec_query "TRUNCATE #{model.quoted_table_name} RESTART IDENTITY CASCADE"
     end
   end


### PR DESCRIPTION
When there are no models to reset a null exception is being raised.
Reference `reset_models` function instead of instance variable as this
will at minimum be an empty array.

Error observed:

```
./tools/dump-responses:35:in `reset_models!': undefined method `each' for nil:NilClass (NoMethodError)
        from ./tools/dump-responses:66:in `block (2 levels) in run_dumps'
        from ./tools/dump-responses:63:in `each'
        from ./tools/dump-responses:63:in `block in run_dumps'
        from ./tools/dump-responses:57:in `each'
        from ./tools/dump-responses:57:in `run_dumps'
        from ./tools/dump-responses:93:in `<main>'
```