### PR TITLE
Use a semantic version constraint for Rails

### DIFF
--- a/rails-response-dumper.gemspec
+++ b/rails-response-dumper.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/Pioneer-Valley-Books/rails-response-dumper'
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
   spec.required_ruby_version = '>= 3.0'
-  spec.add_dependency 'rails', '>= 6.1'
+  spec.add_dependency 'rails', '~> 6.1'
 end


### PR DESCRIPTION
Resolves warning:

    WARNING:  open-ended dependency on rails (>= 6.1) is not recommended
      if rails is semantically versioned, use:
        add_runtime_dependency 'rails', '~> 6.1'