### PR TITLE
Add Gemfile.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ build-iPhoneSimulator/
 /.bundle/
 /vendor/bundle
 /lib/bundler/man/
+Gemfile.lock
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:


### PR DESCRIPTION
For gems (libraries), dependency constraints belong in the gemspec.
Avoid locking dependencies to only a single version and instead allow
installation of any dependency within the supplied semantic range. This
helps ensure that the semantic range is indeed compatible with the gem.

When applications consume the gem, they will use their own Gemfile.lock
and lock both this gem and its dependencies.