### PR TITLE
Use bundler-cache option in ruby/setup-ruby action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0
-
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
 
       - name: RuboCop
         run: bundle exec rubocop


### PR DESCRIPTION
It automatically runs bundle install and caches the result for faster
runs.

https://github.com/ruby/setup-ruby#caching-bundle-install-automatically