### PR TITLE
Override ResponseDumper#inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+- Override `ResponseDumper#inspect` to just the class name without listing its
+  methods.
+
 ## 2.0.0 (2022-02-03)
 
 - Add compatibility for Rails 7.

--- a/bin/rails-response-dumper
+++ b/bin/rails-response-dumper
@@ -54,6 +54,12 @@ class ResponseDumper
       end
     RUBY
   end
+
+  # The list of methods is too long to be useful so shorten to just the class
+  # name.
+  def inspect
+    "#<#{self.class.name}>"
+  end
 end
 
 def run_dumps


### PR DESCRIPTION
The modules inherited by ResponseDumper have many many methods. Avoid
the avalanche of useless text on the screen which hides the interesting
bits.