### PR TITLE
Add support for dumping multiple responses per method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## UNRELEASED
+
+- Allow dumping multiple responses per `dump_*` method. Each additional call to
+  `get` or `post` will dump another file. The directory structure is now:
+
+  ```
+  dumps/class_name/method_name/0.html
+  dumps/class_name/method_name/1.html
+  ...
+  ```
+
 ## 1.1.0 (2022-01-13)
 
 - Instantiate the dumper before each `dump_*` method rather than once before

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ $ rails-response-dumper
 $ tree dumps
 dumps
 └── users_response_dumper
-    └── dump_index.html
+    └── dump_index
+        └── 0.html
 ```
 
 Just like tests, the dump methods can include setup code to add records to the

--- a/bin/rails-response-dumper
+++ b/bin/rails-response-dumper
@@ -40,6 +40,20 @@ class ResponseDumper
   def expect_status_code!(status_code)
     @expected_status_code = Rack::Utils::SYMBOL_TO_STATUS_CODE[status_code]
   end
+
+  def responses
+    @responses ||= []
+  end
+
+  [:get, :post, :patch, :put, :head, :delete].each do |method|
+    module_eval <<~RUBY, __FILE__, __LINE__ + 1
+      def #{method}(...)
+        result = super
+        self.responses << response
+        result
+      end
+    RUBY
+  end
 end
 
 def run_dumps
@@ -50,10 +64,6 @@ def run_dumps
   Dir[Rails.root.join('dumpers/**/*.rb')].each { |f| require f }
 
   ResponseDumper.dumpers.each do |klass|
-    klass_path = klass.name.underscore
-    dumper_dir = "#{dumps_dir}/#{klass_path}"
-    FileUtils.mkdir_p dumper_dir
-
     klass.instance_methods.each do |method|
       next unless method.start_with?('dump_')
 
@@ -66,18 +76,22 @@ def run_dumps
         raise ActiveRecord::Rollback
       end
 
-      response = dumper.response
+      klass_path = klass.name.underscore
+      dumper_dir = "#{dumps_dir}/#{klass_path}/#{method}"
+      FileUtils.mkdir_p dumper_dir
 
-      unless response.status == dumper.expected_status_code
-        raise <<~ERROR.squish
-          Dumped response has unexpected status code #{response.status} #{response.status_message}
-          (expected #{dumper.expected_status_code})
-        ERROR
+      dumper.responses.each_with_index do |response, index|
+        unless response.status == dumper.expected_status_code
+          raise <<~ERROR.squish
+            Dumped response has unexpected status code #{response.status} #{response.status_message}
+            (expected #{dumper.expected_status_code})
+          ERROR
+        end
+
+        mime = response.content_type.split(/ *; */).first
+        extension = MIME::Types[mime].first.preferred_extension
+        File.write("#{dumper_dir}/#{index}.#{extension}", response.body)
       end
-
-      mime = response.content_type.split(/ *; */).first
-      extension = MIME::Types[mime].first.preferred_extension
-      File.write("#{dumper_dir}/#{method}.#{extension}", response.body)
     end
   end
 end


### PR DESCRIPTION
Sometimes after creating setup data, multiple responses should be dumped
to a file. For example, perhaps a series of JSON API calls are all
coupled to one another. Spreading these responses across multiple
methods can result in vastly different data in the output. Those
difference include randomly generated factory data and database IDs.

By dumping multiple responses, they always remain coupled.