### PR TITLE
Include ActiveSupport::Testing::TimeHelpers in ResponseDumper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+- `ResponseDumper` class now includes `ActiveSupport::Testing::TimeHelpers` to
+  provide methods `freeze_time`, `travel`, and `travel_to`.
+
 ## 2.1.0 (2022-03-03)
 
 - Override `ResponseDumper#inspect` to just the class name without listing its

--- a/bin/rails-response-dumper
+++ b/bin/rails-response-dumper
@@ -10,6 +10,7 @@ require "#{Dir.pwd}/config/environment"
 
 class ResponseDumper
   include ActionDispatch::Integration::Runner
+  include ActiveSupport::Testing::TimeHelpers
   include RSpec::Mocks::ExampleMethods
 
   attr_reader :expected_status_code


### PR DESCRIPTION
Provides methods `freeze_time`, `travel`, and `travel_to`.