### PR TITLE
Introduce a DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## UNRELEASED
 
+- New DSL. Library users should no longer define child classes of
+  `ResponseDumper`. Instead, use `ResponseDumper.define`. Inside the block, use
+  the `dump` method. For example:
+
+  ```ruby
+  ResponseDumper.define 'Users' do
+    dump 'index' do
+      get users_index_path
+    end
+  end
+  ```
+
+- The output file structure has changed. Directories no longer contain the
+  `dump_` prefix from methods. For the example above, the output is now:
+
+  ```
+  dumps
+  └── users
+      └── index
+          └── 0.html
+  ```
+
 - `ResponseDumper` class now includes `ActiveSupport::Testing::TimeHelpers` to
   provide methods `freeze_time`, `travel`, and `travel_to`.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ methods are available.
 ```ruby
 # dumpers/users_response_dumper.rb
 
-class UsersResponseDumper < ResponseDumper
-  def dump_index
+ResponseDumper.define 'Users' do
+  dump 'index' do
     get users_index_path
   end
 end
@@ -34,8 +34,8 @@ and fill it with dump files.
 $ rails-response-dumper
 $ tree dumps
 dumps
-└── users_response_dumper
-    └── dump_index
+└── users
+    └── index
         └── 0.html
 ```
 
@@ -43,22 +43,22 @@ Just like tests, the dump methods can include setup code to add records to the
 database or include other side effects to build a more interesting dump. Dumps
 run in a transaction that always rollsback at the end.
 
-## `ResponseDumper::reset_models`
+## `reset_models`
 
 *NOTE: This feature is only supported on PostgreSQL.*
 
-The class method `ResponseDumper::reset_models` can be used to reset database
-sequences between runs. If a model ID value is included in the dump and it is
-important that this value is reproducible on each run, use this method.
+The method `reset_models` can be used to reset database sequences between runs.
+If a model ID value is included in the dump and it is important that this value
+is reproducible on each run, use this method.
 
 
 ```ruby
 # dumpers/users_response_dumper.rb
 
-class UsersResponseDumper < ResponseDumper
+ResponseDumper.define 'Users' do
   reset_models User
 
-  def dump_index
+  dump 'index' do
     User.create!(name: 'Alice')
     get users_index_path
   end

--- a/lib/rails_response_dumper/defined.rb
+++ b/lib/rails_response_dumper/defined.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/module/delegation'
+
+module RailsResponseDumper
+  class Defined
+    attr_accessor :name, :klass
+
+    delegate :include, to: :klass
+
+    def self.dumpers
+      @dumpers ||= []
+    end
+
+    def initialize(name, &block)
+      self.name = name
+      self.klass = Class.new(ResponseDumper)
+
+      instance_eval(&block)
+
+      self.class.dumpers << self
+    end
+
+    def dump(name, &block)
+      blocks << [name, block]
+    end
+
+    def blocks
+      @blocks ||= []
+    end
+
+    def reset_models(*models)
+      @reset_models ||= []
+      @reset_models += models
+    end
+
+    def reset_models!
+      reset_models.each do |model|
+        model.connection.exec_query <<~SQL.squish
+          TRUNCATE #{model.quoted_table_name} RESTART IDENTITY CASCADE
+        SQL
+      end
+    end
+  end
+end

--- a/lib/response_dumper.rb
+++ b/lib/response_dumper.rb
@@ -9,24 +9,8 @@ class ResponseDumper
 
   attr_reader :expected_status_code
 
-  def self.inherited(subclass)
-    super
-    dumpers << subclass
-  end
-
-  def self.dumpers
-    @dumpers ||= []
-  end
-
-  def self.reset_models(*models)
-    @reset_models ||= []
-    @reset_models += models
-  end
-
-  def self.reset_models!
-    reset_models.each do |model|
-      model.connection.exec_query "TRUNCATE #{model.quoted_table_name} RESTART IDENTITY CASCADE"
-    end
+  def self.define(name, &block)
+    RailsResponseDumper::Defined.new(name, &block)
   end
 
   # Delegates to `Rails.application`.


### PR DESCRIPTION
Dumpers are now defined with:

    ResponseDumper.define 'Namespace::Controller' do
      dump 'show' do
        ...
      end
    end

This syntax is heavily inspired b RSpec. The DSL is intended to result
in more readable dumpers and also reduce boilerplate. The dumped file
paths are also shorter as they no longer include the common class suffix
`_response_dumper` or the method prefix `dump_`.