### PR TITLE
Make expected HTTP status code an argument to dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
           └── 0.html
   ```
 
+- The `dump` method has an optional keyword argument `status_code`. Use this if
+  the dumped response has an HTTP status code other than 200.
+
 - `ResponseDumper` class now includes `ActiveSupport::Testing::TimeHelpers` to
   provide methods `freeze_time`, `travel`, and `travel_to`.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ Just like tests, the dump methods can include setup code to add records to the
 database or include other side effects to build a more interesting dump. Dumps
 run in a transaction that always rollsback at the end.
 
+### HTTP Status Codes
+
+By default, Rails Response Dumper will raise an exception if the response does
+not have an HTTP status code 200. If you expect a different status code, use
+the keyword argument `status_code` to `dump`.
+
+```ruby
+# dumpers/users_response_dumper.rb
+
+ResponseDumper.define 'Users' do
+  dump 'show_does_not_exist', status_code: :not_found do
+    get user_path(0)
+  end
+end
+```
+
 ## `reset_models`
 
 *NOTE: This feature is only supported on PostgreSQL.*

--- a/lib/rails_response_dumper/defined.rb
+++ b/lib/rails_response_dumper/defined.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/module/delegation'
+require_relative 'dump_block'
 
 module RailsResponseDumper
   class Defined
@@ -21,8 +22,8 @@ module RailsResponseDumper
       self.class.dumpers << self
     end
 
-    def dump(name, &block)
-      blocks << [name, block]
+    def dump(name, status_code: :ok, &block)
+      blocks << DumpBlock.new(name, Rack::Utils::SYMBOL_TO_STATUS_CODE[status_code], block)
     end
 
     def blocks

--- a/lib/rails_response_dumper/dump_block.rb
+++ b/lib/rails_response_dumper/dump_block.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module RailsResponseDumper
+  DumpBlock = Struct.new('DumpBlock', :name, :expected_status_code, :block)
+end

--- a/lib/response_dumper.rb
+++ b/lib/response_dumper.rb
@@ -7,8 +7,6 @@ class ResponseDumper
   include ActiveSupport::Testing::TimeHelpers
   include RSpec::Mocks::ExampleMethods
 
-  attr_reader :expected_status_code
-
   def self.define(name, &block)
     RailsResponseDumper::Defined.new(name, &block)
   end
@@ -16,10 +14,6 @@ class ResponseDumper
   # Delegates to `Rails.application`.
   def app
     Rails.application
-  end
-
-  def expect_status_code!(status_code)
-    @expected_status_code = Rack::Utils::SYMBOL_TO_STATUS_CODE[status_code]
   end
 
   def responses


### PR DESCRIPTION
Removes the need to call expect_status_code! inside dump methods which
normally contain setup code and requests.