### PR TITLE
Specify rspec-mocks version to fix warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 
 - On status code failure, the error now reports the dumper class and method.
 
+- The rspec-mocks dependency now requires version `~> 3.0` (or `>= 3.0, <
+  4.0`).
+
 ## 2.1.0 (2022-03-03)
 
 - Override `ResponseDumper#inspect` to just the class name without listing its

--- a/rails-response-dumper.gemspec
+++ b/rails-response-dumper.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_runtime_dependency 'rails', '>= 6.1', '< 8'
-  spec.add_runtime_dependency 'rspec-mocks'
+  spec.add_runtime_dependency 'rspec-mocks', '~> 3.0'
 end


### PR DESCRIPTION
Fixes the following warning when building the gem:

    WARNING:  open-ended dependency on rspec-mocks (>= 0) is not recommended
      use a bounded requirement, such as '~> x.y'