### PR TITLE
Add RSpec and a basic test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,3 +19,18 @@ jobs:
 
       - name: RuboCop
         run: bundle exec rubocop
+
+  rspec:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+
+      - name: RSpec
+        run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 /test/version_tmp/
 /tmp/
 
+dumps/
+
 # Used by dotenv library to load environment variables.
 # .env
 
@@ -55,3 +57,7 @@ Gemfile.lock
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+
+# Rails generated files.
+log/
+tmp/

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,10 @@
 
 source 'https://rubygems.org'
 
+gem 'rspec', group: [:development]
 gem 'rubocop', group: [:development]
 gem 'rubocop-performance', group: [:development]
 gem 'rubocop-rails', group: [:development]
+gem 'rubocop-rspec', group: [:development]
 
 gemspec

--- a/spec/app/app/controllers/application_controller.rb
+++ b/spec/app/app/controllers/application_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationController < ActionController::Base
+end

--- a/spec/app/app/controllers/root_controller.rb
+++ b/spec/app/app/controllers/root_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RootController < ApplicationController
+end

--- a/spec/app/app/views/layouts/application.html.erb
+++ b/spec/app/app/views/layouts/application.html.erb
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>App</title>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/spec/app/app/views/root/index.html
+++ b/spec/app/app/views/root/index.html
@@ -1,0 +1,1 @@
+<p>Hello World!</p>

--- a/spec/app/config/application.rb
+++ b/spec/app/config/application.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'boot'
+
+require 'rails'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+
+Bundler.require(*Rails.groups)
+
+module App
+  class Application < Rails::Application
+    config.load_defaults 7.0
+  end
+end

--- a/spec/app/config/boot.rb
+++ b/spec/app/config/boot.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'

--- a/spec/app/config/environment.rb
+++ b/spec/app/config/environment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Load the Rails application.
+require_relative 'application'
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/spec/app/config/environments/test.rb
+++ b/spec/app/config/environments/test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Turn false under Spring and add config.action_view.cache_template_loading = true.
+  config.cache_classes = true
+
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
+  config.eager_load = ENV['CI'].present?
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+  config.cache_store = :null_store
+
+  # Raise exceptions instead of rendering exception templates.
+  config.action_dispatch.show_exceptions = false
+
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
+end

--- a/spec/app/config/locales/en.yml
+++ b/spec/app/config/locales/en.yml
@@ -1,0 +1,33 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t "hello"
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t("hello") %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# The following keys must be escaped otherwise they will not be retrieved by
+# the default I18n backend:
+#
+# true, false, on, off, yes, no
+#
+# Instead, surround them with single quotes.
+#
+# en:
+#   "true": "foo"
+#
+# To learn more, please read the Rails Internationalization guide
+# available at https://guides.rubyonrails.org/i18n.html.
+
+en:
+  hello: "Hello world"

--- a/spec/app/config/routes.rb
+++ b/spec/app/config/routes.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  root 'root#index'
+end

--- a/spec/app/dumpers/root_response_dumper.rb
+++ b/spec/app/dumpers/root_response_dumper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ResponseDumper.define 'Root' do
+  dump 'index' do
+    get root_path
+  end
+end

--- a/spec/app/snapshots/root/index/0.html
+++ b/spec/app/snapshots/root/index/0.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>App</title>
+  </head>
+  <body>
+    <p>Hello World!</p>
+
+  </body>
+</html>

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+APP_DIR = File.expand_path('app', __dir__)
+
+RSpec.describe 'CLI' do
+  it 'renders reproducible dumps' do
+    system('bundle', 'exec', 'rails-response-dumper', chdir: APP_DIR, exception: true)
+    expect(File.join(APP_DIR, 'dumps')).to match_snapshots
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.disable_monkey_patching!
+
+  config.warnings = true
+
+  Dir[File.expand_path('support/**/*.rb', __dir__)].each { |f| require f }
+end

--- a/spec/support/matchers/match_snapshots.rb
+++ b/spec/support/matchers/match_snapshots.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+RSpec::Matchers.define :match_snapshots do |_expected|
+  match do |actual|
+    snapshots = File.expand_path('../snapshots', actual)
+    raise "Snapshot directory #{snapshots} does not exist" unless Dir.exist?(snapshots)
+
+    cmd = ['diff', '--unified', '--recursive', actual, snapshots]
+    @out, err, status = Open3.capture3(*cmd)
+
+    case status.exitstatus
+    when 0
+      true
+    when 1
+      false
+    else
+      raise "Command failed with exit #{status}: #{cmd.join(' ')}\n\n#{err}"
+    end
+  end
+
+  failure_message do |actual|
+    <<~MSG
+      Dumps at #{actual} do not match snapshots.
+
+      #{@out}
+    MSG
+  end
+end


### PR DESCRIPTION
https://relishapp.com/rspec

Add a very basic, minimal Rails app in the spec directory. The spec runs
the CLI on the Rails app and verifies the dumped output matches the
expected result.

The dumps are compared using "snapshots" inspired by Jest snapshot
testing. This ensures each run has byte-for-byte identical results.

https://jestjs.io/docs/snapshot-testing

With the ground work implemented, new tests can be added to fill in
coverage and new features can be accompanied by tests.