### PR TITLE
Declare mime/types as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 - On status code failure, the error now reports the dumper class and method.
 
+- Add mime/types as a dependency.
+
 ## 2.1.0 (2022-03-03)
 
 - Override `ResponseDumper#inspect` to just the class name without listing its

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'mime/types'
 require_relative 'defined'
 
 module RailsResponseDumper

--- a/rails-response-dumper.gemspec
+++ b/rails-response-dumper.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
   spec.required_ruby_version = '>= 3.0'
 
+  spec.add_runtime_dependency 'mime-types', '~> 3.0'
   spec.add_runtime_dependency 'rails', '>= 6.1', '< 8'
   spec.add_runtime_dependency 'rspec-mocks'
 end


### PR DESCRIPTION
The mime/types package is used to parse the response content type. This
worked implicitly when the pakage was already loaded.

Make the relationship explicit in case the consuming Rails app does not
use it.