### PR TITLE
Make ActiveRecord optional

### DIFF
--- a/bin/rails-response-dumper
+++ b/bin/rails-response-dumper
@@ -6,7 +6,7 @@ require 'rails_response_dumper'
 
 # Prevent database truncation if the environment is production.
 abort 'The Rails environment is running in production mode!' if Rails.env.production?
-ActiveRecord::Migration.maintain_test_schema!
+ActiveRecord::Migration.maintain_test_schema! if defined?(ActiveRecord::Base)
 
 runner = RailsResponseDumper::Runner.new
 runner.run_dumps


### PR DESCRIPTION
Allow working with Rails applications that don't use ActiveRecord.

This was discovered when building a minimal Rails app -- which does not
include ActivedRecord -- to run RSpec with.