### PR TITLE
Require 'rspec/mocks' in response_dumper.rb

### DIFF
--- a/lib/response_dumper.rb
+++ b/lib/response_dumper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "#{Dir.pwd}/config/environment"
+require 'rspec/mocks'
 
 class ResponseDumper
   include ActionDispatch::Integration::Runner


### PR DESCRIPTION
Required for RSpec::Mocks::ExampleMethods.

Wasn't noticed before as it was implicitly loaded by the Rails
application.