### PR TITLE
Rescue errors to display after runner completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+- Add error aggregation. An exception raised during the dumper runtime will no
+  longer halt execution. Instead, all errors are displayed after runtime.
+
 ## 4.1.0 (2022-10-18)
 
 - Add support for before/after hooks.

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 
 APP_DIR = File.expand_path('test_apps/app', __dir__)
 AFTER_HOOK_APP_DIR = File.expand_path('test_apps/after_hook', __dir__)
+FAIL_APP_DIR = File.expand_path('test_apps/fail_app', __dir__)
 
 RSpec.describe 'CLI' do
   it 'renders reproducible dumps' do
@@ -16,8 +17,24 @@ RSpec.describe 'CLI' do
     env = { 'TMPDIR' => tmpdir, 'FILENAME' => 'test.out' }
     cmd = %w[bundle exec rails-response-dumper]
     _stdout, stderr, status = Open3.capture3(env, *cmd, chdir: AFTER_HOOK_APP_DIR)
-    expect(stderr).to include('after hook error (RuntimeError)')
+    expect(stderr).to include <<~ERR
+      #{AFTER_HOOK_APP_DIR}/dumpers/after_hook_dumper.rb:8 after_hook.after_hook received after hook error
+      #{AFTER_HOOK_APP_DIR}/dumpers/after_hook_dumper.rb:9:in `block (2 levels) in <top (required)>'
+    ERR
     expect(status.exitstatus).to eq(1)
     expect(File.exist?("#{tmpdir}/#{env.fetch('FILENAME')}")).to eq(true)
+  end
+
+  it 'outputs all errors after execution' do
+    cmd = %w[bundle exec rails-response-dumper]
+    _stdout, stderr, status = Open3.capture3(*cmd, chdir: FAIL_APP_DIR)
+    expect(stderr).to include <<~ERR
+      #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
+      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:48:in `block (3 levels) in run_dumps'
+
+      #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:8 fail_app.invalid_number_of_statuses received 2 responses (expected 1)
+      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:36:in `block (2 levels) in run_dumps'
+    ERR
+    expect(status.exitstatus).to eq(1)
   end
 end

--- a/spec/test_apps/fail_app/app/controllers/application_controller.rb
+++ b/spec/test_apps/fail_app/app/controllers/application_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationController < ActionController::Base
+end

--- a/spec/test_apps/fail_app/app/controllers/root_controller.rb
+++ b/spec/test_apps/fail_app/app/controllers/root_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RootController < ApplicationController
+end

--- a/spec/test_apps/fail_app/app/views/layouts/application.html.erb
+++ b/spec/test_apps/fail_app/app/views/layouts/application.html.erb
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>App</title>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/spec/test_apps/fail_app/app/views/root/index.html.erb
+++ b/spec/test_apps/fail_app/app/views/root/index.html.erb
@@ -1,0 +1,1 @@
+<p>Hello World!</p>

--- a/spec/test_apps/fail_app/config/application.rb
+++ b/spec/test_apps/fail_app/config/application.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'boot'
+
+require 'rails'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+
+Bundler.require(*Rails.groups)
+
+module AfterHook
+  class Application < Rails::Application
+    config.load_defaults 7.0
+  end
+end

--- a/spec/test_apps/fail_app/config/boot.rb
+++ b/spec/test_apps/fail_app/config/boot.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'

--- a/spec/test_apps/fail_app/config/environment.rb
+++ b/spec/test_apps/fail_app/config/environment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Load the Rails application.
+require_relative 'application'
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/spec/test_apps/fail_app/config/environments/test.rb
+++ b/spec/test_apps/fail_app/config/environments/test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Turn false under Spring and add config.action_view.cache_template_loading = true.
+  config.cache_classes = true
+
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
+  config.eager_load = ENV['CI'].present?
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+  config.cache_store = :null_store
+
+  # Raise exceptions instead of rendering exception templates.
+  config.action_dispatch.show_exceptions = false
+
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
+end

--- a/spec/test_apps/fail_app/config/routes.rb
+++ b/spec/test_apps/fail_app/config/routes.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  root 'root#index'
+end

--- a/spec/test_apps/fail_app/dumpers/fail_app_dumper.rb
+++ b/spec/test_apps/fail_app/dumpers/fail_app_dumper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+ResponseDumper.define 'fail_app' do
+  dump 'invalid_status_code', status_codes: [:not_found] do
+    get root_path
+  end
+
+  dump 'invalid_number_of_statuses', status_codes: [:ok] do
+    get root_path
+    get root_path
+  end
+end


### PR DESCRIPTION
If an exception is hit during the dumping process, allow dumper
execution to complete, displaying all errors via stderr at end of
process execution.

Display the name and line number of failing dump block, as well as the
location of the exception.