### PR TITLE
Feature/show progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add error aggregation. An exception raised during the dumper runtime will no
   longer halt execution. Instead, all errors are displayed after runtime.
+- Display real-time dumper status during dump execution.
 
 ## 4.1.0 (2022-10-18)
 

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -59,6 +59,8 @@ module RailsResponseDumper
             end
             File.write("#{dumper_dir}/#{index}#{extension}", response.body)
           end
+
+          print '.'
         rescue StandardError => e
           errors << {
             dumper_location: dump_block.block.source_location.join(':'),
@@ -66,9 +68,12 @@ module RailsResponseDumper
             message: e.exception.message,
             backtrace: e.cause&.backtrace || e.exception.backtrace
           }
+
+          print 'F'
         end
       end
 
+      puts
       return if errors.blank?
 
       errors.each do |error|


### PR DESCRIPTION
As the dumper executes, output the status of individual dump blocks with
a '.' or 'F', allowing the user to see that the process is still being
executed, and showing early indication of dumper failure.