### PR TITLE
Colorize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Move all CLI output to stdout. 
 
+- Colorize CLI output for TTY environments.
+
 ## 5.0.0 (2022-12-05)
 
 - Add error aggregation. An exception raised during the dumper runtime will no

--- a/lib/rails_response_dumper/colorize.rb
+++ b/lib/rails_response_dumper/colorize.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RailsResponseDumper
+  COLORS = {
+    cyan: 36,
+    green: 32,
+    red: 31
+  }.freeze
+
+  COLORIZE = $stdout.tty?
+
+  def self.print_color(text, color)
+    if COLORIZE
+      print colorize(text, color)
+    else
+      print text
+    end
+  end
+
+  def self.colorize(text, color)
+    "\e[#{COLORS[color]}m#{text}\e[0m"
+  end
+end

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'defined'
+require_relative 'colorize'
 
 module RailsResponseDumper
   class Runner
@@ -65,7 +66,7 @@ module RailsResponseDumper
             File.write("#{dumper_dir}/#{index}.json", JSON.pretty_generate(dump))
           end
 
-          print '.'
+          RailsResponseDumper.print_color('.', :green)
         rescue StandardError => e
           errors << {
             dumper_location: dump_block.block.source_location.join(':'),
@@ -74,7 +75,7 @@ module RailsResponseDumper
             backtrace: e.cause&.backtrace || e.exception.backtrace
           }
 
-          print 'F'
+          RailsResponseDumper.print_color('F', :red)
         end
       end
 
@@ -82,8 +83,11 @@ module RailsResponseDumper
       return if errors.blank?
 
       errors.each do |error|
-        print "#{error[:dumper_location]} #{error[:name]} received #{error[:message]}\n"
-        print "#{error[:backtrace][0]}\n\n"
+        RailsResponseDumper.print_color(
+          "#{error[:dumper_location]} #{error[:name]} received #{error[:message]}\n",
+          :red
+        )
+        RailsResponseDumper.print_color("#{error[:backtrace][0]}\n\n", :cyan)
       end
 
       exit(false)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe 'CLI' do
     expect(stdout).to include <<~ERR
       FF
       #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
-      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:47:in `block (3 levels) in run_dumps'
+      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:48:in `block (3 levels) in run_dumps'
 
       #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:8 fail_app.invalid_number_of_statuses received 2 responses (expected 1)
-      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:35:in `block (2 levels) in run_dumps'
+      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:36:in `block (2 levels) in run_dumps'
     ERR
     expect(status.exitstatus).to eq(1)
   end

--- a/spec/colorize_spec.rb
+++ b/spec/colorize_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require './lib/rails_response_dumper/colorize'
+
+RSpec.describe 'Colorize' do
+  describe '#print_color' do
+    RailsResponseDumper::COLORS.each do |color, code|
+      context 'when the output is sent to a TTY' do
+        before { stub_const('RailsResponseDumper::COLORIZE', true) }
+        let(:print_color) { RailsResponseDumper.print_color('hello!', color) }
+
+        it 'includes color information in the output' do
+          expect { print_color }.to output("\e[#{code}mhello!\e[0m").to_stdout
+        end
+      end
+
+      context 'when the output is not sent to a TTY' do
+        before { stub_const('RailsResponseDumper::COLORIZE', false) }
+        let(:print_color) { RailsResponseDumper.print_color('hello!', color) }
+
+        it 'does not include color information in the output' do
+          expect { print_color }.to output('hello!').to_stdout
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
putting this up early so i don't forget about it :)

i'd like a cleaner way of dealing the status indicators (only reset colors if the color is going to change) + text should only be colorized if colors are enabled for the  execution environment