### PR TITLE
Include an HTTP status line and response headers in dumps

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,14 @@
+inherit_mode:
+  merge:
+    - Exclude
+
 require:
   - rubocop-performance
 
 AllCops:
   NewCops: enable
+  Exclude:
+    - '**/snapshots/**/*'
 
 Metrics:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 - Add error aggregation. An exception raised during the dumper runtime will no
   longer halt execution. Instead, all errors are displayed after runtime.
+
 - Display real-time dumper status during dump execution.
+
+- The dumped responses now contain an HTTP status line and HTTP headers. Each
+  header line ends with a carriage return and line feed. The headers are
+  separated from the body by an empty line consisting of a carriage return and
+  line feed.
 
 ## 4.1.0 (2022-10-18)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ dumps
         └── 0.html
 ```
 
+The content of the dump files looks like an HTTP response. It has an HTTP
+status line, response headers, an empty line, and the response body. Each
+header line ends with a carriage return and line feed. For example:
+
+```
+HTTP 200 OK
+Content-Type: text/html; charset=utf-8
+Content-Length: 19
+
+<p>Hello World!</p>
+```
+
 Just like tests, the dump methods can include setup code to add records to the
 database or include other side effects to build a more interesting dump. Dumps
 run in a transaction that always rollsback at the end.

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -57,7 +57,15 @@ module RailsResponseDumper
             else
               extension = ''
             end
-            File.write("#{dumper_dir}/#{index}#{extension}", response.body)
+
+            File.open("#{dumper_dir}/#{index}#{extension}", 'w') do |f|
+              f.write "HTTP #{response.status} #{response.status_message}\r\n"
+              response.headers.each do |key, value|
+                f.write "#{key}: #{value}\r\n"
+              end
+              f.write "\r\n"
+              f.write response.body
+            end
           end
 
           print '.'

--- a/spec/test_apps/after_hook/config/application.rb
+++ b/spec/test_apps/after_hook/config/application.rb
@@ -11,5 +11,8 @@ Bundler.require(*Rails.groups)
 module AfterHook
   class Application < Rails::Application
     config.load_defaults 7.0
+    # Avoid non-deterministic headers
+    config.middleware.delete ActionDispatch::RequestId
+    config.middleware.delete Rack::Runtime
   end
 end

--- a/spec/test_apps/app/config/application.rb
+++ b/spec/test_apps/app/config/application.rb
@@ -11,5 +11,8 @@ Bundler.require(*Rails.groups)
 module App
   class Application < Rails::Application
     config.load_defaults 7.0
+    # Avoid non-deterministic headers
+    config.middleware.delete ActionDispatch::RequestId
+    config.middleware.delete Rack::Runtime
   end
 end

--- a/spec/test_apps/app/snapshots/hooks/hook/0.html
+++ b/spec/test_apps/app/snapshots/hooks/hook/0.html
@@ -1,3 +1,15 @@
+HTTP 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 0
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Referrer-Policy: strict-origin-when-cross-origin
+Content-Type: text/html; charset=utf-8
+ETag: W/"d596f8d8528e0c873dc798bc7352f08d"
+Cache-Control: max-age=0, private, must-revalidate
+Content-Length: 141
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/spec/test_apps/app/snapshots/root/index/0.html
+++ b/spec/test_apps/app/snapshots/root/index/0.html
@@ -1,3 +1,15 @@
+HTTP 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 0
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Referrer-Policy: strict-origin-when-cross-origin
+Content-Type: text/html; charset=utf-8
+ETag: W/"1c80359a742d7373dc4561d5d1807c11"
+Cache-Control: max-age=0, private, must-revalidate
+Content-Length: 127
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/0.html
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/0.html
@@ -1,3 +1,15 @@
+HTTP 200 OK
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 0
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Referrer-Policy: strict-origin-when-cross-origin
+Content-Type: text/html; charset=utf-8
+ETag: W/"1c80359a742d7373dc4561d5d1807c11"
+Cache-Control: max-age=0, private, must-revalidate
+Content-Length: 127
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/1
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/1
@@ -1,0 +1,9 @@
+HTTP 204 No Content
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 0
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Referrer-Policy: strict-origin-when-cross-origin
+Cache-Control: no-cache
+

--- a/spec/test_apps/fail_app/config/application.rb
+++ b/spec/test_apps/fail_app/config/application.rb
@@ -11,5 +11,8 @@ Bundler.require(*Rails.groups)
 module AfterHook
   class Application < Rails::Application
     config.load_defaults 7.0
+    # Avoid non-deterministic headers
+    config.middleware.delete ActionDispatch::RequestId
+    config.middleware.delete Rack::Runtime
   end
 end


### PR DESCRIPTION
The dumped responses now contain an HTTP status line and HTTP headers. Each header line ends with a carriage return and line feed. The headers are separated from the body by an empty line consisting of a carriage return and line feed.

This makes the dumps provide more information about the response that can be used in client side testing. For example, the status code or content type might be useful when interpreting the dump file.