### PR TITLE
Move output to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- Move all CLI output to stdout. 
+
 ## 5.0.0 (2022-12-05)
 
 - Add error aggregation. An exception raised during the dumper runtime will no

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -82,8 +82,8 @@ module RailsResponseDumper
       return if errors.blank?
 
       errors.each do |error|
-        $stderr.print "#{error[:dumper_location]} #{error[:name]} received #{error[:message]}\n"
-        $stderr.print "#{error[:backtrace][0]}\n\n"
+        print "#{error[:dumper_location]} #{error[:name]} received #{error[:message]}\n"
+        print "#{error[:backtrace][0]}\n\n"
       end
 
       exit(false)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -11,9 +11,8 @@ RSpec.describe 'CLI' do
   it 'renders reproducible dumps' do
     cmd = %w[bundle exec rails-response-dumper]
     stdout, stderr, status = Open3.capture3(*cmd, chdir: APP_DIR)
-
-    expect(stdout).to eq("...\n")
     expect(stderr).to eq('')
+    expect(stdout).to eq("...\n")
     expect(status.exitstatus).to eq(0)
 
     expect(File.join(APP_DIR, 'dumps')).to match_snapshots
@@ -23,8 +22,9 @@ RSpec.describe 'CLI' do
     env = { 'TMPDIR' => tmpdir, 'FILENAME' => 'test.out' }
     cmd = %w[bundle exec rails-response-dumper]
     stdout, stderr, status = Open3.capture3(env, *cmd, chdir: AFTER_HOOK_APP_DIR)
-    expect(stdout).to eq("F\n")
-    expect(stderr).to include <<~ERR
+    expect(stderr).to eq('')
+    expect(stdout).to include <<~ERR
+      F
       #{AFTER_HOOK_APP_DIR}/dumpers/after_hook_dumper.rb:8 after_hook.after_hook received after hook error
       #{AFTER_HOOK_APP_DIR}/dumpers/after_hook_dumper.rb:9:in `block (2 levels) in <top (required)>'
     ERR
@@ -35,8 +35,9 @@ RSpec.describe 'CLI' do
   it 'outputs all errors after execution' do
     cmd = %w[bundle exec rails-response-dumper]
     stdout, stderr, status = Open3.capture3(*cmd, chdir: FAIL_APP_DIR)
-    expect(stdout).to eq("FF\n")
-    expect(stderr).to include <<~ERR
+    expect(stderr).to eq('')
+    expect(stdout).to include <<~ERR
+      FF
       #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
       #{Dir.getwd}/lib/rails_response_dumper/runner.rb:47:in `block (3 levels) in run_dumps'
 


### PR DESCRIPTION
Having all output go to a single stream allows testing feedback (both
the status line and the post-run error summary) to be piped to a single
location in a consistent manner.
