### PR TITLE
Include the request body in the dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 ## UNRELEASED
 
-- Move all CLI output to stdout. 
+- Move all CLI output to stdout.
 
 - Colorize CLI output for TTY environments.
+
+- The request body is now included in the dump. The new format looks like:
+
+  ```json
+  {
+    "request": {
+      "method": "GET",
+      "url": "http://www.example.com/test",
+      "body": ""
+    },
+    "response": {
+      "status": 200,
+      "headers": {
+        "Content-Type": "text/html; charset=utf-8",
+        ...
+      },
+      "body": "..."
+    }
+  }
+  ```
 
 ## 5.0.0 (2022-12-05)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ information about the HTTP request and response. For example:
 {
   "request": {
     "method": "GET",
-    "url": "http://www.example.com/test"
+    "url": "http://www.example.com/test",
+    "body": ""
   },
   "response": {
     "status": 200,

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -55,7 +55,8 @@ module RailsResponseDumper
             dump = {
               request: {
                 method: request.method,
-                url: request.url
+                url: request.url,
+                body: request.body.string
               },
               response: {
                 status: response.status,

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'CLI' do
     cmd = %w[bundle exec rails-response-dumper]
     stdout, stderr, status = Open3.capture3(*cmd, chdir: APP_DIR)
     expect(stderr).to eq('')
-    expect(stdout).to eq("...\n")
+    expect(stdout).to eq("....\n")
     expect(status.exitstatus).to eq(0)
 
     expect(File.join(APP_DIR, 'dumps')).to match_snapshots

--- a/spec/test_apps/app/app/controllers/tests_controller.rb
+++ b/spec/test_apps/app/app/controllers/tests_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class TestsController < ApplicationController
+  def create; end
+
   def destroy; end
 end

--- a/spec/test_apps/app/config/routes.rb
+++ b/spec/test_apps/app/config/routes.rb
@@ -3,5 +3,5 @@
 Rails.application.routes.draw do
   root 'root#index'
 
-  resource :tests, only: [:destroy]
+  resource :tests, only: %i[create destroy]
 end

--- a/spec/test_apps/app/dumpers/tests_response_dumper.rb
+++ b/spec/test_apps/app/dumpers/tests_response_dumper.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 ResponseDumper.define 'Tests' do
+  dump 'post_with_body', status_codes: %i[no_content no_content] do
+    post url_for(controller: :tests, action: :create), params: { foo: { bar: 'baz' } }
+    post url_for(controller: :tests, action: :create), as: :json, params: { foo: { bar: 'baz' } }
+  end
+
   dump 'multiple_requests', status_codes: %i[ok no_content] do
     get root_path
     delete url_for(controller: :tests, action: :destroy)

--- a/spec/test_apps/app/snapshots/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots/hooks/hook/0.json
@@ -1,7 +1,8 @@
 {
   "request": {
     "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "body": ""
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots/root/index/0.json
+++ b/spec/test_apps/app/snapshots/root/index/0.json
@@ -1,7 +1,8 @@
 {
   "request": {
     "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "body": ""
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
@@ -1,7 +1,8 @@
 {
   "request": {
     "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "body": ""
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots/tests/post_with_body/0.json
@@ -1,8 +1,8 @@
 {
   "request": {
-    "method": "DELETE",
+    "method": "POST",
     "url": "http://www.example.com/tests",
-    "body": ""
+    "body": "foo[bar]=baz"
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots/tests/post_with_body/1.json
@@ -1,8 +1,8 @@
 {
   "request": {
-    "method": "DELETE",
+    "method": "POST",
     "url": "http://www.example.com/tests",
-    "body": ""
+    "body": "{\"foo\":{\"bar\":\"baz\"}}"
   },
   "response": {
     "status": 204,


### PR DESCRIPTION
The new format looks like:

    {
      "request": {
        "method": "GET",
        "url": "http://www.example.com/test",
        "body": ""
      },
      "response": {
        "status": 200,
        "headers": {
          "Content-Type": "text/html; charset=utf-8",
          ...
        },
        "body": "..."
      }
    }