### PR TITLE
Include the response status code in the dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Colorize CLI output for TTY environments.
 
-- The request body is now included in the dump. The new format looks like:
+-  The request body and the response status text are now included in the dump.
+   The new format looks like:
 
   ```json
   {
@@ -15,6 +16,7 @@
     },
     "response": {
       "status": 200,
+      "status_text": "OK",
       "headers": {
         "Content-Type": "text/html; charset=utf-8",
         ...

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ information about the HTTP request and response. For example:
   },
   "response": {
     "status": 200,
+    "status_text": "OK",
     "headers": {
       "Content-Type": "text/html; charset=utf-8",
       ...

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -60,6 +60,7 @@ module RailsResponseDumper
               },
               response: {
                 status: response.status,
+                status_text: response.status_message,
                 headers: response.headers,
                 body: response.body
               }

--- a/spec/test_apps/app/snapshots/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots/hooks/hook/0.json
@@ -6,6 +6,7 @@
   },
   "response": {
     "status": 200,
+    "status_text": "OK",
     "headers": {
       "X-Frame-Options": "SAMEORIGIN",
       "X-XSS-Protection": "0",

--- a/spec/test_apps/app/snapshots/root/index/0.json
+++ b/spec/test_apps/app/snapshots/root/index/0.json
@@ -6,6 +6,7 @@
   },
   "response": {
     "status": 200,
+    "status_text": "OK",
     "headers": {
       "X-Frame-Options": "SAMEORIGIN",
       "X-XSS-Protection": "0",

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
@@ -6,6 +6,7 @@
   },
   "response": {
     "status": 200,
+    "status_text": "OK",
     "headers": {
       "X-Frame-Options": "SAMEORIGIN",
       "X-XSS-Protection": "0",

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/1.json
@@ -6,6 +6,7 @@
   },
   "response": {
     "status": 204,
+    "status_text": "No Content",
     "headers": {
       "X-Frame-Options": "SAMEORIGIN",
       "X-XSS-Protection": "0",

--- a/spec/test_apps/app/snapshots/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots/tests/post_with_body/0.json
@@ -6,6 +6,7 @@
   },
   "response": {
     "status": 204,
+    "status_text": "No Content",
     "headers": {
       "X-Frame-Options": "SAMEORIGIN",
       "X-XSS-Protection": "0",

--- a/spec/test_apps/app/snapshots/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots/tests/post_with_body/1.json
@@ -6,6 +6,7 @@
   },
   "response": {
     "status": 204,
+    "status_text": "No Content",
     "headers": {
       "X-Frame-Options": "SAMEORIGIN",
       "X-XSS-Protection": "0",


### PR DESCRIPTION
Can be used by consumers to create more representative mocked response data.