### PR TITLE
Output the full backtrace when reporting errors

### DIFF
--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -73,8 +73,7 @@ module RailsResponseDumper
           errors << {
             dumper_location: dump_block.block.source_location.join(':'),
             name: "#{defined.name}.#{dump_block.name}",
-            message: e.exception.message,
-            backtrace: e.cause&.backtrace || e.exception.backtrace
+            exception: e
           }
 
           RailsResponseDumper.print_color('F', :red)
@@ -84,12 +83,16 @@ module RailsResponseDumper
       puts
       return if errors.blank?
 
+      puts
       errors.each do |error|
         RailsResponseDumper.print_color(
-          "#{error[:dumper_location]} #{error[:name]} received #{error[:message]}\n",
+          "#{error[:dumper_location]} #{error[:name]} received #{error[:exception]}\n",
           :red
         )
-        RailsResponseDumper.print_color("#{error[:backtrace][0]}\n\n", :cyan)
+        error[:exception].full_message(highlight: RailsResponseDumper::COLORIZE).lines do |line|
+          RailsResponseDumper.print_color(line, :cyan)
+        end
+        puts
       end
 
       exit(false)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe 'CLI' do
     cmd = %w[bundle exec rails-response-dumper]
     stdout, stderr, status = Open3.capture3(env, *cmd, chdir: AFTER_HOOK_APP_DIR)
     expect(stderr).to eq('')
+    expect(stdout.lines[0]).to eq("F\n")
     expect(stdout).to include <<~ERR
-      F
       #{AFTER_HOOK_APP_DIR}/dumpers/after_hook_dumper.rb:8 after_hook.after_hook received after hook error
-      #{AFTER_HOOK_APP_DIR}/dumpers/after_hook_dumper.rb:9:in `block (2 levels) in <top (required)>'
+      #{AFTER_HOOK_APP_DIR}/dumpers/after_hook_dumper.rb:9:in `block (2 levels) in <top (required)>': after hook error (RuntimeError)
     ERR
     expect(status.exitstatus).to eq(1)
     expect(File.exist?("#{tmpdir}/#{env.fetch('FILENAME')}")).to eq(true)
@@ -36,13 +36,14 @@ RSpec.describe 'CLI' do
     cmd = %w[bundle exec rails-response-dumper]
     stdout, stderr, status = Open3.capture3(*cmd, chdir: FAIL_APP_DIR)
     expect(stderr).to eq('')
+    expect(stdout.lines[0]).to eq("FF\n")
     expect(stdout).to include <<~ERR
-      FF
       #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
-      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:48:in `block (3 levels) in run_dumps'
-
+      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:48:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
+    ERR
+    expect(stdout).to include <<~ERR
       #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:8 fail_app.invalid_number_of_statuses received 2 responses (expected 1)
-      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:36:in `block (2 levels) in run_dumps'
+      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:36:in `block (2 levels) in run_dumps': 2 responses (expected 1) (RuntimeError)
     ERR
     expect(status.exitstatus).to eq(1)
   end


### PR DESCRIPTION
When an error occurs, more context is often needed for debugging, so show it all.