### PR TITLE
Add --fail-fast cli option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- Add ability to abort after first error using `--fail-fast` CLI flag.
+
 ## 5.1.0 (2022-12-12)
 
 - Move all CLI output to stdout.

--- a/bin/rails-response-dumper
+++ b/bin/rails-response-dumper
@@ -8,5 +8,5 @@ require 'rails_response_dumper'
 abort 'The Rails environment is running in production mode!' if Rails.env.production?
 ActiveRecord::Migration.maintain_test_schema! if defined?(ActiveRecord::Base)
 
-runner = RailsResponseDumper::Runner.new
+runner = RailsResponseDumper::Runner.new(RailsResponseDumper.parse_options!)
 runner.run_dumps

--- a/lib/rails_response_dumper.rb
+++ b/lib/rails_response_dumper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
+require_relative 'rails_response_dumper/option_parser'
 require_relative 'rails_response_dumper/runner'
 require_relative 'response_dumper'

--- a/lib/rails_response_dumper/option_parser.rb
+++ b/lib/rails_response_dumper/option_parser.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+module RailsResponseDumper
+  def self.parse_options!
+    options = {}
+
+    OptionParser.new do |opts|
+      opts.on('--fail-fast', 'Abort the run after first failure.') do |v|
+        options[:fail_fast] = v
+      end
+    end.parse!
+
+    options.freeze
+  end
+end

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -5,6 +5,12 @@ require_relative 'colorize'
 
 module RailsResponseDumper
   class Runner
+    attr_reader :options
+
+    def initialize(options)
+      @options = options
+    end
+
     def run_dumps
       dumps_dir = Rails.root.join('dumps')
       FileUtils.rm_rf dumps_dir
@@ -77,6 +83,8 @@ module RailsResponseDumper
           }
 
           RailsResponseDumper.print_color('F', :red)
+
+          break if options[:fail_fast]
         end
       end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -32,19 +32,38 @@ RSpec.describe 'CLI' do
     expect(File.exist?("#{tmpdir}/#{env.fetch('FILENAME')}")).to eq(true)
   end
 
-  it 'outputs all errors after execution' do
-    cmd = %w[bundle exec rails-response-dumper]
-    stdout, stderr, status = Open3.capture3(*cmd, chdir: FAIL_APP_DIR)
-    expect(stderr).to eq('')
-    expect(stdout.lines[0]).to eq("FF\n")
-    expect(stdout).to include <<~ERR
-      #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
-      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:48:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
-    ERR
-    expect(stdout).to include <<~ERR
-      #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:8 fail_app.invalid_number_of_statuses received 2 responses (expected 1)
-      #{Dir.getwd}/lib/rails_response_dumper/runner.rb:36:in `block (2 levels) in run_dumps': 2 responses (expected 1) (RuntimeError)
-    ERR
-    expect(status.exitstatus).to eq(1)
+  context 'when there are errors in the dumpers' do
+    let(:invalid_number_of_statuses) { 'fail_app.invalid_number_of_statuses' }
+
+    it 'outputs all errors after execution' do
+      cmd = %w[bundle exec rails-response-dumper]
+      stdout, stderr, status = Open3.capture3(*cmd, chdir: FAIL_APP_DIR)
+      expect(stderr).to eq('')
+      expect(stdout.lines[0]).to eq("FF\n")
+      expect(stdout).to include <<~ERR
+        #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
+        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:54:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
+      ERR
+      expect(stdout).to include <<~ERR
+        #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:8 #{invalid_number_of_statuses} received 2 responses (expected 1)
+        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:42:in `block (2 levels) in run_dumps': 2 responses (expected 1) (RuntimeError)
+      ERR
+      expect(status.exitstatus).to eq(1)
+    end
+
+    context 'with --fail-fast argument' do
+      it 'aborts after the first error' do
+        cmd = %w[bundle exec rails-response-dumper --fail-fast]
+        stdout, stderr, status = Open3.capture3(*cmd, chdir: FAIL_APP_DIR)
+        expect(stderr).to eq('')
+        expect(stdout.lines[0]).to eq("F\n")
+        expect(stdout).to include <<~ERR
+          #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
+          #{Dir.getwd}/lib/rails_response_dumper/runner.rb:54:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
+        ERR
+        expect(stdout).not_to include(invalid_number_of_statuses)
+        expect(status.exitstatus).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
The option naming was inspired by rspec.

This option will abort rails-response-dumper after first error.

Without the flag it will capture all errors as usual.

e.g. `bundle exec rails-response-dumper --fail-fast`

fixes https://github.com/Pioneer-Valley-Books/rails-response-dumper/issues/55