### PR TITLE
Fix --fail-fast option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+- Add fix to `--fail-fast` CLI flag.  Abort dumps for all remaining dumpers,
+and not just the dumps of the current dumper in the loop.
+
 ## 5.2.0 (2023-01-24)
 
 - Output the full backtrace when reporting errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UNRELEASED
 
-- Add fix to `--fail-fast` CLI flag.  Abort dumps for all remaining dumpers,
+- Fix `--fail-fast` CLI flag. Abort dumps for all remaining dumpers,
 and not just the dumps of the current dumper in the loop.
 
 ## 5.2.0 (2023-01-24)

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -20,71 +20,73 @@ module RailsResponseDumper
 
       errors = []
 
-      RailsResponseDumper::Defined.dumpers.each do |defined|
-        defined.blocks.each do |dump_block|
-          defined.reset_models!
-          dumper = defined.klass.new
-          dumper.mock_setup
-          begin
-            rollback_after do
-              dumper.instance_eval(&defined.before_block) if defined.before_block
-              begin
-                dumper.instance_eval(&dump_block.block)
-              ensure
-                dumper.instance_eval(&defined.after_block) if defined.after_block
+      catch :fail_fast do
+        RailsResponseDumper::Defined.dumpers.each do |defined|
+          defined.blocks.each do |dump_block|
+            defined.reset_models!
+            dumper = defined.klass.new
+            dumper.mock_setup
+            begin
+              rollback_after do
+                dumper.instance_eval(&defined.before_block) if defined.before_block
+                begin
+                  dumper.instance_eval(&dump_block.block)
+                ensure
+                  dumper.instance_eval(&defined.after_block) if defined.after_block
+                end
               end
+            ensure
+              dumper.mock_teardown
             end
-          ensure
-            dumper.mock_teardown
-          end
 
-          unless dumper.responses.count == dump_block.expected_status_codes.count
-            raise <<~ERROR.squish
-              #{dumper.responses.count} responses
-              (expected #{dump_block.expected_status_codes.count})
-            ERROR
-          end
-
-          klass_path = defined.name.underscore
-          dumper_dir = "#{dumps_dir}/#{klass_path}/#{dump_block.name}"
-          FileUtils.mkdir_p dumper_dir
-
-          dumper.responses.each_with_index do |response, index|
-            unless response.status == dump_block.expected_status_codes[index]
+            unless dumper.responses.count == dump_block.expected_status_codes.count
               raise <<~ERROR.squish
-                unexpected status code #{response.status} #{response.status_message}
-                (expected #{dump_block.expected_status_codes[index]})
+                #{dumper.responses.count} responses
+                (expected #{dump_block.expected_status_codes.count})
               ERROR
             end
 
-            request = response.request
-            dump = {
-              request: {
-                method: request.method,
-                url: request.url,
-                body: request.body.string
-              },
-              response: {
-                status: response.status,
-                status_text: response.status_message,
-                headers: response.headers,
-                body: response.body
+            klass_path = defined.name.underscore
+            dumper_dir = "#{dumps_dir}/#{klass_path}/#{dump_block.name}"
+            FileUtils.mkdir_p dumper_dir
+
+            dumper.responses.each_with_index do |response, index|
+              unless response.status == dump_block.expected_status_codes[index]
+                raise <<~ERROR.squish
+                  unexpected status code #{response.status} #{response.status_message}
+                  (expected #{dump_block.expected_status_codes[index]})
+                ERROR
+              end
+
+              request = response.request
+              dump = {
+                request: {
+                  method: request.method,
+                  url: request.url,
+                  body: request.body.string
+                },
+                response: {
+                  status: response.status,
+                  status_text: response.status_message,
+                  headers: response.headers,
+                  body: response.body
+                }
               }
+              File.write("#{dumper_dir}/#{index}.json", JSON.pretty_generate(dump))
+            end
+
+            RailsResponseDumper.print_color('.', :green)
+          rescue StandardError => e
+            errors << {
+              dumper_location: dump_block.block.source_location.join(':'),
+              name: "#{defined.name}.#{dump_block.name}",
+              exception: e
             }
-            File.write("#{dumper_dir}/#{index}.json", JSON.pretty_generate(dump))
+
+            RailsResponseDumper.print_color('F', :red)
+
+            throw :fail_fast if options[:fail_fast]
           end
-
-          RailsResponseDumper.print_color('.', :green)
-        rescue StandardError => e
-          errors << {
-            dumper_location: dump_block.block.source_location.join(':'),
-            name: "#{defined.name}.#{dump_block.name}",
-            exception: e
-          }
-
-          RailsResponseDumper.print_color('F', :red)
-
-          break if options[:fail_fast]
         end
       end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -34,19 +34,24 @@ RSpec.describe 'CLI' do
 
   context 'when there are errors in the dumpers' do
     let(:invalid_number_of_statuses) { 'fail_app.invalid_number_of_statuses' }
+    let(:dumper_2_invalid_status_code) { 'fail_app_2.invalid_status_code' }
 
     it 'outputs all errors after execution' do
       cmd = %w[bundle exec rails-response-dumper]
       stdout, stderr, status = Open3.capture3(*cmd, chdir: FAIL_APP_DIR)
       expect(stderr).to eq('')
-      expect(stdout.lines[0]).to eq("FF\n")
+      expect(stdout.lines[0]).to eq("FFF\n")
       expect(stdout).to include <<~ERR
         #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
-        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:54:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
+        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:55:in `block (4 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
       ERR
       expect(stdout).to include <<~ERR
         #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:8 #{invalid_number_of_statuses} received 2 responses (expected 1)
-        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:42:in `block (2 levels) in run_dumps': 2 responses (expected 1) (RuntimeError)
+        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:43:in `block (3 levels) in run_dumps': 2 responses (expected 1) (RuntimeError)
+      ERR
+      expect(stdout).to include <<~ERR
+        #{FAIL_APP_DIR}/dumpers/fail_app_dumper_2.rb:4 #{dumper_2_invalid_status_code} received unexpected status code 200 OK (expected 404)
+        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:55:in `block (4 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
       ERR
       expect(status.exitstatus).to eq(1)
     end
@@ -59,9 +64,10 @@ RSpec.describe 'CLI' do
         expect(stdout.lines[0]).to eq("F\n")
         expect(stdout).to include <<~ERR
           #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
-          #{Dir.getwd}/lib/rails_response_dumper/runner.rb:54:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
+          #{Dir.getwd}/lib/rails_response_dumper/runner.rb:55:in `block (4 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
         ERR
         expect(stdout).not_to include(invalid_number_of_statuses)
+        expect(stdout).not_to include(dumper_2_invalid_status_code)
         expect(status.exitstatus).to eq(1)
       end
     end

--- a/spec/test_apps/fail_app/dumpers/fail_app_dumper_2.rb
+++ b/spec/test_apps/fail_app/dumpers/fail_app_dumper_2.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ResponseDumper.define 'fail_app_2' do
+  dump 'invalid_status_code', status_codes: [:not_found] do
+    get root_path
+  end
+end


### PR DESCRIPTION
The first implementation was only breaking early out of the loop that iterated through a single dumper's dumps.

However, it would then move on to the next dumper as usual.

This update will exit both loops and correctly abort after first failure.

Added a second dumper to the fail_app specs to verify this was working correctly.