### PR TITLE
Add --order CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## UNRELEASED
 
+- Add --order CLI option.  `--order random` will run the dumps in a random
+order. If given a seed value e.g. `--order 8` it will initialize the pseudo
+random number generator with the provided seed value to run the dumps in a
+reproducible order.
+
 - Fix `--fail-fast` CLI flag. Abort dumps for all remaining dumpers,
 and not just the dumps of the current dumper in the loop.
 

--- a/lib/rails_response_dumper/option_parser.rb
+++ b/lib/rails_response_dumper/option_parser.rb
@@ -14,6 +14,10 @@ module RailsResponseDumper
       opts.on('--verbose', 'Output dumper and dump block names.') do |v|
         options[:verbose] = v
       end
+
+      opts.on('--order TYPE', 'Run dumps by the specified order type.') do |v|
+        options[:order] = v
+      end
     end.parse!
 
     options.freeze


### PR DESCRIPTION
The option naming was inspired by rspec.

`--order random` will run the dumps in a random order.

If given a seed value e.g. `--order 8` it will initialize the pseudo random number generator with the provided seed value to run the dumps in a reproducible order.

fixes #60