### PR TITLE
Add CLI option to exclude response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UNRELEASED
 
-- Add `--exclude-response-headers` CLI option.  This option will supress response
+- Add `--exclude-response-headers` CLI option.  This option will suppress response
 headers from the dumper output.
 
 ## 5.3.0 (2023-03-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+- Add `--exclude-response-headers` CLI option.  This option will supress response
+headers from the dumper output.
+
 ## 5.3.0 (2023-03-07)
 
 - Add `--verbose` CLI option.  This option will print the dumper and block names.

--- a/lib/rails_response_dumper/option_parser.rb
+++ b/lib/rails_response_dumper/option_parser.rb
@@ -19,7 +19,7 @@ module RailsResponseDumper
         options[:order] = v
       end
 
-      opts.on('--exclude-response-headers', 'Do not output response headers') do |v|
+      opts.on('--exclude-response-headers', 'Do not output response headers.') do |v|
         options[:exclude_response_headers] = v
       end
     end.parse!

--- a/lib/rails_response_dumper/option_parser.rb
+++ b/lib/rails_response_dumper/option_parser.rb
@@ -18,6 +18,10 @@ module RailsResponseDumper
       opts.on('--order TYPE', 'Run dumps by the specified order type.') do |v|
         options[:order] = v
       end
+
+      opts.on('--exclude-response-headers', 'Do not output response headers') do |v|
+        options[:exclude_response_headers] = v
+      end
     end.parse!
 
     options.freeze

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -90,7 +90,7 @@ module RailsResponseDumper
               response: {
                 status: response.status,
                 status_text: response.status_message,
-                headers: response.headers,
+                # headers: response.headers,
                 body: response.body
               }
             }

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -81,6 +81,9 @@ module RailsResponseDumper
             end
 
             request = response.request
+
+            response_headers = options[:exclude_response_headers] ? {} : response.headers
+
             dump = {
               request: {
                 method: request.method,
@@ -90,7 +93,7 @@ module RailsResponseDumper
               response: {
                 status: response.status,
                 status_text: response.status_message,
-                # headers: response.headers,
+                headers: response_headers,
                 body: response.body
               }
             }

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -82,8 +82,6 @@ module RailsResponseDumper
 
             request = response.request
 
-            response_headers = options[:exclude_response_headers] ? {} : response.headers
-
             dump = {
               request: {
                 method: request.method,
@@ -93,10 +91,13 @@ module RailsResponseDumper
               response: {
                 status: response.status,
                 status_text: response.status_message,
-                headers: response_headers,
+                headers: response.headers,
                 body: response.body
               }
             }
+
+            dump[:response].delete(:headers) if options[:exclude_response_headers]
+
             File.write("#{dumper_dir}/#{index}.json", JSON.pretty_generate(dump))
           end
 

--- a/rails-response-dumper.gemspec
+++ b/rails-response-dumper.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'rails-response-dumper'
-  spec.version = '5.4.0'
+  spec.version = '5.3.0'
   spec.licenses = ['MIT']
   spec.summary = 'Dump HTTP responses from a Rails application to the file system'
   spec.authors = ['Pioneer Valley Books']

--- a/rails-response-dumper.gemspec
+++ b/rails-response-dumper.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'rails-response-dumper'
-  spec.version = '5.3.0'
+  spec.version = '5.4.0'
   spec.licenses = ['MIT']
   spec.summary = 'Dump HTTP responses from a Rails application to the file system'
   spec.authors = ['Pioneer Valley Books']

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe 'CLI' do
     end
   end
 
+  context 'with --exclude-response-headers argument' do
+    it 'renders dumps without response headers' do
+      cmd = %w[bundle exec rails-response-dumper --exclude-response-headers]
+      stdout, stderr, status = Open3.capture3(*cmd, chdir: APP_DIR)
+      expect(stderr).to eq('')
+      expect(stdout).to eq("....\n")
+      expect(status.exitstatus).to eq(0)
+
+      expect(File.join(APP_DIR, 'dumps')).to match_snapshots(File.join(APP_DIR, 'snapshots_without_response_headers'))
+    end
+  end
+
   context 'when run with --order' do
     context 'with type "random"' do
       it 'renders reproducible dumps with random seed' do

--- a/spec/support/matchers/match_snapshots.rb
+++ b/spec/support/matchers/match_snapshots.rb
@@ -2,9 +2,9 @@
 
 require 'open3'
 
-RSpec::Matchers.define :match_snapshots do |_expected|
+RSpec::Matchers.define :match_snapshots do |snapshots = nil|
   match do |actual|
-    snapshots = File.expand_path('../snapshots', actual)
+    snapshots ||= File.expand_path('../snapshots', actual)
     raise "Snapshot directory #{snapshots} does not exist" unless Dir.exist?(snapshots)
 
     cmd = ['diff', '--unified', '--recursive', actual, snapshots]

--- a/spec/test_apps/app/snapshots_without_response_headers/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/hooks/hook/0.json
@@ -7,8 +7,6 @@
   "response": {
     "status": 200,
     "status_text": "OK",
-    "headers": {
-    },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n  <p>Test</p>\n\n  </body>\n</html>\n"
   }
 }

--- a/spec/test_apps/app/snapshots_without_response_headers/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/hooks/hook/0.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "http://www.example.com/",
+    "body": ""
+  },
+  "response": {
+    "status": 200,
+    "status_text": "OK",
+    "headers": {
+    },
+    "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n  <p>Test</p>\n\n  </body>\n</html>\n"
+  }
+}

--- a/spec/test_apps/app/snapshots_without_response_headers/root/index/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/root/index/0.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "http://www.example.com/",
+    "body": ""
+  },
+  "response": {
+    "status": 200,
+    "status_text": "OK",
+    "headers": {
+    },
+    "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
+  }
+}

--- a/spec/test_apps/app/snapshots_without_response_headers/root/index/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/root/index/0.json
@@ -7,8 +7,6 @@
   "response": {
     "status": 200,
     "status_text": "OK",
-    "headers": {
-    },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
   }
 }

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/0.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "http://www.example.com/",
+    "body": ""
+  },
+  "response": {
+    "status": 200,
+    "status_text": "OK",
+    "headers": {
+    },
+    "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
+  }
+}

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/0.json
@@ -7,8 +7,6 @@
   "response": {
     "status": 200,
     "status_text": "OK",
-    "headers": {
-    },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
   }
 }

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/1.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "DELETE",
+    "url": "http://www.example.com/tests",
+    "body": ""
+  },
+  "response": {
+    "status": 204,
+    "status_text": "No Content",
+    "headers": {
+    },
+    "body": ""
+  }
+}

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/1.json
@@ -7,8 +7,6 @@
   "response": {
     "status": 204,
     "status_text": "No Content",
-    "headers": {
-    },
     "body": ""
   }
 }

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/0.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "http://www.example.com/tests",
+    "body": "foo[bar]=baz"
+  },
+  "response": {
+    "status": 204,
+    "status_text": "No Content",
+    "headers": {
+    },
+    "body": ""
+  }
+}

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/0.json
@@ -7,8 +7,6 @@
   "response": {
     "status": 204,
     "status_text": "No Content",
-    "headers": {
-    },
     "body": ""
   }
 }

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/1.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "http://www.example.com/tests",
+    "body": "{\"foo\":{\"bar\":\"baz\"}}"
+  },
+  "response": {
+    "status": 204,
+    "status_text": "No Content",
+    "headers": {
+    },
+    "body": ""
+  }
+}

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/1.json
@@ -7,8 +7,6 @@
   "response": {
     "status": 204,
     "status_text": "No Content",
-    "headers": {
-    },
     "body": ""
   }
 }


### PR DESCRIPTION
Add CLI option to exclude response headers.

Response headers could make response dumper output nondeterministic.  
To help with test environments that do not require response headers the CLI option
can now be used to filter out the extra content.

The snapshot test helper was updated to allow for optionally specifying a non standard
snapshot directory to help test both including and excluding response headers on the
test app.