### PR TITLE
[PROPOSAL] Allow runtime configuration options

### DIFF
--- a/lib/rails_response_dumper.rb
+++ b/lib/rails_response_dumper.rb
@@ -3,3 +3,10 @@
 require_relative 'rails_response_dumper/option_parser'
 require_relative 'rails_response_dumper/runner'
 require_relative 'response_dumper'
+
+module RailsResponseDumper
+  def self.merge_options(options)
+    current_runner = Thread.current[:current_rails_response_runner]
+    current_runner.merge_options(options)
+  end
+end

--- a/lib/rails_response_dumper/option_parser.rb
+++ b/lib/rails_response_dumper/option_parser.rb
@@ -24,6 +24,6 @@ module RailsResponseDumper
       end
     end.parse!
 
-    options.freeze
+    options
   end
 end

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -11,7 +11,13 @@ module RailsResponseDumper
       @options = options
     end
 
+    def merge_options(options)
+      @options = @options.merge(options)
+    end
+
     def run_dumps
+      Thread.current[:current_rails_response_runner] = self
+
       dumps_dir = Rails.root.join('dumps')
       FileUtils.rm_rf dumps_dir
       FileUtils.mkdir_p dumps_dir
@@ -114,6 +120,8 @@ module RailsResponseDumper
           print("\n") if options[:verbose]
 
           throw :fail_fast if options[:fail_fast]
+        ensure
+          Thread.current[:current_rails_response_runner] = nil
         end
       end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -6,6 +6,7 @@ require 'spec_helper'
 APP_DIR = File.expand_path('test_apps/app', __dir__)
 AFTER_HOOK_APP_DIR = File.expand_path('test_apps/after_hook', __dir__)
 FAIL_APP_DIR = File.expand_path('test_apps/fail_app', __dir__)
+RUNTIME_OPTIONS_APP_DIR = File.expand_path('test_apps/runtime_options', __dir__)
 
 RSpec.describe 'CLI' do
   it 'renders reproducible dumps' do
@@ -99,15 +100,15 @@ RSpec.describe 'CLI' do
       expect(stdout.lines[0]).to eq("FFF\n")
       expect(stdout).to include <<~ERR
         #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
-        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:77:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
+        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:83:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
       ERR
       expect(stdout).to include <<~ERR
         #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:8 #{invalid_number_of_statuses} received 2 responses (expected 1)
-        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:65:in `block (2 levels) in run_dumps': 2 responses (expected 1) (RuntimeError)
+        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:71:in `block (2 levels) in run_dumps': 2 responses (expected 1) (RuntimeError)
       ERR
       expect(stdout).to include <<~ERR
         #{FAIL_APP_DIR}/dumpers/fail_app_dumper_2.rb:4 #{dumper_2_invalid_status_code} received unexpected status code 200 OK (expected 404)
-        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:77:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
+        #{Dir.getwd}/lib/rails_response_dumper/runner.rb:83:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
       ERR
       expect(status.exitstatus).to eq(1)
     end
@@ -120,12 +121,22 @@ RSpec.describe 'CLI' do
         expect(stdout.lines[0]).to eq("F\n")
         expect(stdout).to include <<~ERR
           #{FAIL_APP_DIR}/dumpers/fail_app_dumper.rb:4 fail_app.invalid_status_code received unexpected status code 200 OK (expected 404)
-          #{Dir.getwd}/lib/rails_response_dumper/runner.rb:77:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
+          #{Dir.getwd}/lib/rails_response_dumper/runner.rb:83:in `block (3 levels) in run_dumps': unexpected status code 200 OK (expected 404) (RuntimeError)
         ERR
         expect(stdout).not_to include(invalid_number_of_statuses)
         expect(stdout).not_to include(dumper_2_invalid_status_code)
         expect(status.exitstatus).to eq(1)
       end
     end
+  end
+
+  it 'respects runtime options' do
+    cmd = %w[bundle exec rails-response-dumper]
+    stdout, stderr, status = Open3.capture3(*cmd, chdir: RUNTIME_OPTIONS_APP_DIR)
+    expect(stderr).to eq('')
+    expect(stdout).to eq(".\n")
+    expect(status.exitstatus).to eq(0)
+
+    expect(File.join(RUNTIME_OPTIONS_APP_DIR, 'dumps')).to match_snapshots
   end
 end

--- a/spec/test_apps/runtime_options/app/controllers/application_controller.rb
+++ b/spec/test_apps/runtime_options/app/controllers/application_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationController < ActionController::Base
+end

--- a/spec/test_apps/runtime_options/app/controllers/root_controller.rb
+++ b/spec/test_apps/runtime_options/app/controllers/root_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RootController < ApplicationController
+end

--- a/spec/test_apps/runtime_options/app/views/layouts/application.html.erb
+++ b/spec/test_apps/runtime_options/app/views/layouts/application.html.erb
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>App</title>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/spec/test_apps/runtime_options/app/views/root/index.html.erb
+++ b/spec/test_apps/runtime_options/app/views/root/index.html.erb
@@ -1,0 +1,1 @@
+<p>Hello World!</p>

--- a/spec/test_apps/runtime_options/config/application.rb
+++ b/spec/test_apps/runtime_options/config/application.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative 'boot'
+
+require 'rails'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+
+Bundler.require(*Rails.groups)
+
+module AfterHook
+  class Application < Rails::Application
+    config.load_defaults 7.0
+    # Avoid non-deterministic headers
+    config.middleware.delete ActionDispatch::RequestId
+    config.middleware.delete Rack::Runtime
+  end
+end

--- a/spec/test_apps/runtime_options/config/boot.rb
+++ b/spec/test_apps/runtime_options/config/boot.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'

--- a/spec/test_apps/runtime_options/config/environment.rb
+++ b/spec/test_apps/runtime_options/config/environment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Load the Rails application.
+require_relative 'application'
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/spec/test_apps/runtime_options/config/environments/test.rb
+++ b/spec/test_apps/runtime_options/config/environments/test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Turn false under Spring and add config.action_view.cache_template_loading = true.
+  config.cache_classes = true
+
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
+  config.eager_load = ENV['CI'].present?
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+  config.cache_store = :null_store
+
+  # Raise exceptions instead of rendering exception templates.
+  config.action_dispatch.show_exceptions = false
+
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
+end

--- a/spec/test_apps/runtime_options/config/routes.rb
+++ b/spec/test_apps/runtime_options/config/routes.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  root 'root#index'
+end

--- a/spec/test_apps/runtime_options/dumpers/response_dumper_helper.rb
+++ b/spec/test_apps/runtime_options/dumpers/response_dumper_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RailsResponseDumper.merge_options({
+                                    exclude_response_headers: true
+                                  })

--- a/spec/test_apps/runtime_options/dumpers/root_response_dumper.rb
+++ b/spec/test_apps/runtime_options/dumpers/root_response_dumper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ResponseDumper.define 'Root' do
+  dump 'index' do
+    get root_path
+  end
+end

--- a/spec/test_apps/runtime_options/snapshots/root/index/0.json
+++ b/spec/test_apps/runtime_options/snapshots/root/index/0.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "http://www.example.com/",
+    "body": ""
+  },
+  "response": {
+    "status": 200,
+    "status_text": "OK",
+    "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
+  }
+}


### PR DESCRIPTION
To allow a project to configure rails-response-dumper options we can add an api
that will allow updating options for the running dumper.  This allows for setting up
a dumper_helper.rb analogous to spec_helper.rb that can configure options so that
running the `bundle exec rails-response-dumper` command will create standard project
output.

```ruby
# dumpers/response_dumper_helper.rb

RailsResponseDumper.merge_options({
  exclude_response_headers: true
})
```