### PR TITLE
Use unique tmp directory for dump output for every spec context

### DIFF
--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -12,7 +12,7 @@ module RailsResponseDumper
     end
 
     def run_dumps
-      dumps_dir = Rails.root.join('dumps')
+      dumps_dir = ENV['DUMPS_DIR'] || Rails.root.join('dumps')
       FileUtils.rm_rf dumps_dir
       FileUtils.mkdir_p dumps_dir
 


### PR DESCRIPTION
- Allows running tests in parallel and prevents the output of previous tests from impacting downstream tests