### PR TITLE
Start database transaction with `joinable: false` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+- Start the database transaction with the `joinable: false` argument passed.
+  This allows model `after_commit` hooks to run and improves compatibility with
+  ActiveStorage.
+
 ## 6.0.0 (2023-04-27)
 
 - Add `--dumps-dir` CLI option. This option allows the user to specify a

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ gem 'rubocop', group: [:development]
 gem 'rubocop-performance', group: [:development]
 gem 'rubocop-rails', group: [:development]
 gem 'rubocop-rspec', group: [:development]
+gem 'sqlite3', group: [:development]
 
 gemspec

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -153,7 +153,7 @@ module RailsResponseDumper
 
     def rollback_after
       if defined?(ActiveRecord::Base)
-        ActiveRecord::Base.transaction do
+        ActiveRecord::Base.transaction(joinable: false) do
           yield
           raise ActiveRecord::Rollback
         end

--- a/spec/test_apps/.rubocop.yml
+++ b/spec/test_apps/.rubocop.yml
@@ -1,5 +1,0 @@
-inherit_from:
-  - ../../.rubocop.yml
-
-require:
-  - rubocop-rails

--- a/spec/test_apps/app/Rakefile
+++ b/spec/test_apps/app/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+require_relative 'config/application'
+
+Rails.application.load_tasks

--- a/spec/test_apps/app/app/controllers/books_controller.rb
+++ b/spec/test_apps/app/app/controllers/books_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BooksController < ApplicationController
+  def create
+    Book.create!
+  end
+end

--- a/spec/test_apps/app/app/models/application_record.rb
+++ b/spec/test_apps/app/app/models/application_record.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+  primary_abstract_class
+end

--- a/spec/test_apps/app/app/models/book.rb
+++ b/spec/test_apps/app/app/models/book.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Book < ApplicationRecord
+  after_commit do
+    puts 'Commit Book' if ENV['AFTER_COMMIT']
+  end
+end

--- a/spec/test_apps/app/bin/rails
+++ b/spec/test_apps/app/bin/rails
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+APP_PATH = File.expand_path('../config/application', __dir__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/spec/test_apps/app/config/application.rb
+++ b/spec/test_apps/app/config/application.rb
@@ -3,6 +3,7 @@
 require_relative 'boot'
 
 require 'rails'
+require 'active_record/railtie'
 require 'action_controller/railtie'
 require 'action_view/railtie'
 

--- a/spec/test_apps/app/config/routes.rb
+++ b/spec/test_apps/app/config/routes.rb
@@ -3,5 +3,6 @@
 Rails.application.routes.draw do
   root 'root#index'
 
+  resource :books, only: %i[create]
   resource :tests, only: %i[create destroy]
 end

--- a/spec/test_apps/app/db/migrate/0000_create_books.rb
+++ b/spec/test_apps/app/db/migrate/0000_create_books.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateBooks < ActiveRecord::Migration[7.0]
+  def change
+    create_table 'books' do |t|
+      t.datetime 'created_at', null: false
+      t.datetime 'updated_at', null: false
+    end
+  end
+end

--- a/spec/test_apps/app/db/schema.rb
+++ b/spec/test_apps/app/db/schema.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 0) do
+  create_table 'books', force: :cascade do |t|
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+  end
+end

--- a/spec/test_apps/app/dumpers/books_response_dumper.rb
+++ b/spec/test_apps/app/dumpers/books_response_dumper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ResponseDumper.define 'Books' do
+  dump 'create', status_codes: %i[no_content] do
+    post url_for(controller: :books, action: :create)
+  end
+end

--- a/spec/test_apps/app/snapshots/books/create/0.json
+++ b/spec/test_apps/app/snapshots/books/create/0.json
@@ -1,0 +1,21 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "http://www.example.com/books",
+    "body": ""
+  },
+  "response": {
+    "status": 204,
+    "statusText": "No Content",
+    "headers": {
+      "X-Frame-Options": "SAMEORIGIN",
+      "X-XSS-Protection": "0",
+      "X-Content-Type-Options": "nosniff",
+      "X-Download-Options": "noopen",
+      "X-Permitted-Cross-Domain-Policies": "none",
+      "Referrer-Policy": "strict-origin-when-cross-origin",
+      "Cache-Control": "no-cache"
+    },
+    "body": ""
+  }
+}

--- a/spec/test_apps/app/snapshots_updated_dump/books/create/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/books/create/0.json
@@ -1,0 +1,21 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "http://www.example.com/books",
+    "body": ""
+  },
+  "response": {
+    "status": 204,
+    "statusText": "No Content",
+    "headers": {
+      "X-Frame-Options": "SAMEORIGIN",
+      "X-XSS-Protection": "0",
+      "X-Content-Type-Options": "nosniff",
+      "X-Download-Options": "noopen",
+      "X-Permitted-Cross-Domain-Policies": "none",
+      "Referrer-Policy": "strict-origin-when-cross-origin",
+      "Cache-Control": "no-cache"
+    },
+    "body": ""
+  }
+}

--- a/spec/test_apps/app/snapshots_without_response_headers/books/create/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/books/create/0.json
@@ -1,0 +1,12 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "http://www.example.com/books",
+    "body": ""
+  },
+  "response": {
+    "status": 204,
+    "statusText": "No Content",
+    "body": ""
+  }
+}


### PR DESCRIPTION
In order for model after_commit hooks to execute, the first transaction must be started with `joinable: false`. This is the strategy used by Rails test classes.

This is especially important for use with ActiveStorage which uses the after_commit hook to upload the file to the service.