### PR TITLE
Add `timestamp` property to dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+- Add `timestamp` property to dumps. Its value is the Rails timestamp in ISO
+  8601 format.
+
 ## 6.1.0 (2023-05-24)
 
 - Start the database transaction with the `joinable: false` argument passed.

--- a/lib/rails_response_dumper/option_parser.rb
+++ b/lib/rails_response_dumper/option_parser.rb
@@ -36,6 +36,10 @@ module RailsResponseDumper
       opts.on('--exclude-response-headers', 'Do not output response headers.') do |v|
         options[:exclude_response_headers] = v
       end
+
+      opts.on('--exclude-timestamp', 'Do not output a timestamp with each dump.') do |v|
+        options[:exclude_timestamp] = v
+      end
     end.parse!
 
     options[:filenames] = ARGV

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -86,7 +86,7 @@ module RailsResponseDumper
           dumper_dir = "#{dumps_dir}/#{klass_path}/#{dump_block.name}"
           FileUtils.mkdir_p dumper_dir
 
-          dumper.responses.each_with_index do |response, index|
+          dumper.responses.each_with_index do |(response, timestamp), index|
             unless response.status == dump_block.expected_status_codes[index]
               raise <<~ERROR.squish
                 unexpected status code #{response.status} #{response.status_message}
@@ -111,6 +111,8 @@ module RailsResponseDumper
             }
 
             dump[:response].delete(:headers) if options[:exclude_response_headers]
+
+            dump[:timestamp] = timestamp.iso8601 unless options[:exclude_timestamp]
 
             File.write("#{dumper_dir}/#{index}.json", JSON.pretty_generate(dump))
           end

--- a/lib/response_dumper.rb
+++ b/lib/response_dumper.rb
@@ -35,7 +35,7 @@ class ResponseDumper
     module_eval <<~RUBY, __FILE__, __LINE__ + 1
       def #{method}(...)
         result = super
-        self.responses << response
+        self.responses << [response, Time.zone.now]
         result
       end
     RUBY


### PR DESCRIPTION
Its value is the Rails timestamp in ISO 8601 format.

This value could be used to stub or fake the system time to better match the environment of that generated the dump.