### PR TITLE
Update snapshots to match Rack 3

### DIFF
--- a/spec/test_apps/app/snapshots/books/create/0.json
+++ b/spec/test_apps/app/snapshots/books/create/0.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots/hooks/hook/0.json
@@ -8,16 +8,16 @@
     "status": 200,
     "statusText": "OK",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Content-Type": "text/html; charset=utf-8",
-      "ETag": "W/\"d596f8d8528e0c873dc798bc7352f08d\"",
-      "Cache-Control": "max-age=0, private, must-revalidate",
-      "Content-Length": "141"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "content-type": "text/html; charset=utf-8",
+      "etag": "W/\"d596f8d8528e0c873dc798bc7352f08d\"",
+      "cache-control": "max-age=0, private, must-revalidate",
+      "content-length": "141"
     },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n  <p>Test</p>\n\n  </body>\n</html>\n"
   }

--- a/spec/test_apps/app/snapshots/root/index/0.json
+++ b/spec/test_apps/app/snapshots/root/index/0.json
@@ -8,16 +8,16 @@
     "status": 200,
     "statusText": "OK",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Content-Type": "text/html; charset=utf-8",
-      "ETag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
-      "Cache-Control": "max-age=0, private, must-revalidate",
-      "Content-Length": "127"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "content-type": "text/html; charset=utf-8",
+      "etag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
+      "cache-control": "max-age=0, private, must-revalidate",
+      "content-length": "127"
     },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
   }

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
@@ -8,16 +8,16 @@
     "status": 200,
     "statusText": "OK",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Content-Type": "text/html; charset=utf-8",
-      "ETag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
-      "Cache-Control": "max-age=0, private, must-revalidate",
-      "Content-Length": "127"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "content-type": "text/html; charset=utf-8",
+      "etag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
+      "cache-control": "max-age=0, private, must-revalidate",
+      "content-length": "127"
     },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
   }

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/1.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots/tests/post_with_body/0.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots/tests/post_with_body/1.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/0.json
@@ -8,16 +8,16 @@
     "status": 200,
     "statusText": "OK",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Content-Type": "text/html; charset=utf-8",
-      "ETag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
-      "Cache-Control": "max-age=0, private, must-revalidate",
-      "Content-Length": "127"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "content-type": "text/html; charset=utf-8",
+      "etag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
+      "cache-control": "max-age=0, private, must-revalidate",
+      "content-length": "127"
     },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
   }

--- a/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/1.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_single_file/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/post_with_body/0.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_single_file/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/post_with_body/1.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_two_files/root/index/0.json
+++ b/spec/test_apps/app/snapshots_two_files/root/index/0.json
@@ -8,16 +8,16 @@
     "status": 200,
     "statusText": "OK",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Content-Type": "text/html; charset=utf-8",
-      "ETag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
-      "Cache-Control": "max-age=0, private, must-revalidate",
-      "Content-Length": "127"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "content-type": "text/html; charset=utf-8",
+      "etag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
+      "cache-control": "max-age=0, private, must-revalidate",
+      "content-length": "127"
     },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
   }

--- a/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/0.json
@@ -8,16 +8,16 @@
     "status": 200,
     "statusText": "OK",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Content-Type": "text/html; charset=utf-8",
-      "ETag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
-      "Cache-Control": "max-age=0, private, must-revalidate",
-      "Content-Length": "127"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "content-type": "text/html; charset=utf-8",
+      "etag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
+      "cache-control": "max-age=0, private, must-revalidate",
+      "content-length": "127"
     },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
   }

--- a/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/1.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_two_files/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/post_with_body/0.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_two_files/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/post_with_body/1.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_updated_dump/books/create/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/books/create/0.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_updated_dump/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/hooks/hook/0.json
@@ -8,16 +8,16 @@
     "status": 200,
     "statusText": "OK",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Content-Type": "text/html; charset=utf-8",
-      "ETag": "W/\"d596f8d8528e0c873dc798bc7352f08d\"",
-      "Cache-Control": "max-age=0, private, must-revalidate",
-      "Content-Length": "141"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "content-type": "text/html; charset=utf-8",
+      "etag": "W/\"d596f8d8528e0c873dc798bc7352f08d\"",
+      "cache-control": "max-age=0, private, must-revalidate",
+      "content-length": "141"
     },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n  <p>Test</p>\n\n  </body>\n</html>\n"
   }

--- a/spec/test_apps/app/snapshots_updated_dump/root/index/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/root/index/0.json
@@ -8,16 +8,16 @@
     "status": 200,
     "statusText": "OK",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Content-Type": "text/html; charset=utf-8",
-      "ETag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
-      "Cache-Control": "max-age=0, private, must-revalidate",
-      "Content-Length": "127"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "content-type": "text/html; charset=utf-8",
+      "etag": "W/\"1c80359a742d7373dc4561d5d1807c11\"",
+      "cache-control": "max-age=0, private, must-revalidate",
+      "content-length": "127"
     },
     "body": "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <title>App</title>\n  </head>\n  <body>\n    <p>Hello World!</p>\n\n  </body>\n</html>\n"
   }

--- a/spec/test_apps/app/snapshots_updated_dump/tests/another_post/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/tests/another_post/0.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_updated_dump/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/tests/post_with_body/0.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }

--- a/spec/test_apps/app/snapshots_updated_dump/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots_updated_dump/tests/post_with_body/1.json
@@ -8,13 +8,13 @@
     "status": 204,
     "statusText": "No Content",
     "headers": {
-      "X-Frame-Options": "SAMEORIGIN",
-      "X-XSS-Protection": "0",
-      "X-Content-Type-Options": "nosniff",
-      "X-Download-Options": "noopen",
-      "X-Permitted-Cross-Domain-Policies": "none",
-      "Referrer-Policy": "strict-origin-when-cross-origin",
-      "Cache-Control": "no-cache"
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "0",
+      "x-content-type-options": "nosniff",
+      "x-download-options": "noopen",
+      "x-permitted-cross-domain-policies": "none",
+      "referrer-policy": "strict-origin-when-cross-origin",
+      "cache-control": "no-cache"
     },
     "body": ""
   }


### PR DESCRIPTION
Rack now lowercases all header names. See the changelog:

https://github.com/rack/rack/blob/main/CHANGELOG.md

> Response header keys can no longer include uppercase characters.

> Rack::Headers added to support lower-case header keys.