### PR TITLE
Fix: Expand Gemfile.lock platform support as intended

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,8 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   rails-response-dumper!


### PR DESCRIPTION
This more fully updates the Gemfile.lock which began in version control with PR #88, which should have deleted and rebuilt the Gemfile.lock after making it platform agnostic. The `bundle install` changes which came with the platform change itself were not themselves sufficient.