### PR TITLE
Include CGI/HTTP request Rack env variables in the JSON dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- Include CGI/HTTP request rack environment variables in the JSON dump.
+
 ## 7.0.0 (2024-02-29)
 
 - Add the `--profile` CLI option. This option will print the names of the 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UNRELEASED
 
-- Include CGI/HTTP request rack environment variables in the JSON dump.
+- Include CGI/HTTP request Rack environment variables in the JSON dump.
 
 ## 7.0.0 (2024-02-29)
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ information about the HTTP request and response. For example:
 ```json
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/test"
+    "url": "http://www.example.com/test",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      ...
+    }
   },
   "response": {
     "status": 200,

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -102,8 +102,8 @@ module RailsResponseDumper
 
             dump = {
               request: {
-                method: request.method,
-                url: request.url
+                url: request.url,
+                env: request.headers.to_h
               },
               response: {
                 status: response.status,
@@ -111,6 +111,12 @@ module RailsResponseDumper
                 headers: response.headers
               }
             }
+
+            # request.headers includes nonstandard internal data, some of which also lacks default deterministic
+            # serialization. Here we only want CGI standard and HTTP variables.
+            dump[:request][:env].delete_if do |key, _|
+              !(key.in?(ActionDispatch::Http::Headers::CGI_VARIABLES) || key =~ /^HTTP_/)
+            end
 
             dump[:response].delete(:headers) if options[:exclude_response_headers]
 

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -115,7 +115,7 @@ module RailsResponseDumper
             # request.headers includes nonstandard internal data, some of which also lacks default deterministic
             # serialization. Here we only want CGI standard and HTTP variables.
             dump[:request][:env].filter! do |key|
-              key.in?(ActionDispatch::Http::Headers::CGI_VARIABLES) || key =~ /\AHTTP_/
+              key.in?(ActionDispatch::Http::Headers::CGI_VARIABLES) || key.start_with?('HTTP_')
             end
 
             dump[:response].delete(:headers) if options[:exclude_response_headers]

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -114,8 +114,8 @@ module RailsResponseDumper
 
             # request.headers includes nonstandard internal data, some of which also lacks default deterministic
             # serialization. Here we only want CGI standard and HTTP variables.
-            dump[:request][:env].delete_if do |key|
-              !(key.in?(ActionDispatch::Http::Headers::CGI_VARIABLES) || key =~ /^HTTP_/)
+            dump[:request][:env].filter! do |key|
+              key.in?(ActionDispatch::Http::Headers::CGI_VARIABLES) || key =~ /\AHTTP_/
             end
 
             dump[:response].delete(:headers) if options[:exclude_response_headers]

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -114,7 +114,7 @@ module RailsResponseDumper
 
             # request.headers includes nonstandard internal data, some of which also lacks default deterministic
             # serialization. Here we only want CGI standard and HTTP variables.
-            dump[:request][:env].delete_if do |key, _|
+            dump[:request][:env].delete_if do |key|
               !(key.in?(ActionDispatch::Http::Headers::CGI_VARIABLES) || key =~ /^HTTP_/)
             end
 

--- a/spec/test_apps/app/snapshots/books/create/0.json
+++ b/spec/test_apps/app/snapshots/books/create/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/books"
+    "url": "http://www.example.com/books",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/books",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots/hooks/hook/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots/root/index/0.json
+++ b/spec/test_apps/app/snapshots/root/index/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots/tests/multipart_formdata_request_with_file/0.json
+++ b/spec/test_apps/app/snapshots/tests/multipart_formdata_request_with_file/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests/submit_image"
+    "url": "http://www.example.com/tests/submit_image",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests/submit_image",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "214",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "multipart/form-data; boundary=----------XnJLe9ZIbbGUYtzPQJ16u1",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/1.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "DELETE",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "DELETE",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots/tests/post_with_body/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "12",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots/tests/post_with_body/1.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "21",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "application/json",
+      "CONTENT_TYPE": "application/json",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_single_file/tests/multipart_formdata_request_with_file/0.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/multipart_formdata_request_with_file/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests/submit_image"
+    "url": "http://www.example.com/tests/submit_image",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests/submit_image",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "214",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "multipart/form-data; boundary=----------XnJLe9ZIbbGUYtzPQJ16u1",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/1.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "DELETE",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "DELETE",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_single_file/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/post_with_body/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "12",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_single_file/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/post_with_body/1.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "21",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "application/json",
+      "CONTENT_TYPE": "application/json",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_two_files/root/index/0.json
+++ b/spec/test_apps/app/snapshots_two_files/root/index/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots_two_files/tests/multipart_formdata_request_with_file/0.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/multipart_formdata_request_with_file/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests/submit_image"
+    "url": "http://www.example.com/tests/submit_image",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests/submit_image",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "214",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "multipart/form-data; boundary=----------XnJLe9ZIbbGUYtzPQJ16u1",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/1.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "DELETE",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "DELETE",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_two_files/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/post_with_body/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "12",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_two_files/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/post_with_body/1.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "21",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "application/json",
+      "CONTENT_TYPE": "application/json",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_updated_dump/books/create/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/books/create/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/books"
+    "url": "http://www.example.com/books",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/books",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_updated_dump/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/hooks/hook/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots_updated_dump/root/index/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/root/index/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots_updated_dump/tests/another_post/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/tests/another_post/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "13",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_updated_dump/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/tests/post_with_body/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "13",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_updated_dump/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots_updated_dump/tests/post_with_body/1.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "22",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "application/json",
+      "CONTENT_TYPE": "application/json",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_without_response_headers/books/create/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/books/create/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/books"
+    "url": "http://www.example.com/books",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/books",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_without_response_headers/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/hooks/hook/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots_without_response_headers/root/index/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/root/index/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/multipart_formdata_request_with_file/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/multipart_formdata_request_with_file/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests/submit_image"
+    "url": "http://www.example.com/tests/submit_image",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests/submit_image",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "214",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "multipart/form-data; boundary=----------XnJLe9ZIbbGUYtzPQJ16u1",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/0.json
@@ -1,7 +1,21 @@
 {
   "request": {
-    "method": "GET",
-    "url": "http://www.example.com/"
+    "url": "http://www.example.com/",
+    "env": {
+      "REQUEST_METHOD": "GET",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 200,

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/1.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/1.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "DELETE",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "DELETE",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "0",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/0.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "12",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
+      "CONTENT_TYPE": "application/x-www-form-urlencoded",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/1.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/post_with_body/1.json
@@ -1,7 +1,22 @@
 {
   "request": {
-    "method": "POST",
-    "url": "http://www.example.com/tests"
+    "url": "http://www.example.com/tests",
+    "env": {
+      "REQUEST_METHOD": "POST",
+      "SERVER_NAME": "www.example.com",
+      "SERVER_PORT": "80",
+      "SERVER_PROTOCOL": "HTTP/1.0",
+      "QUERY_STRING": "",
+      "PATH_INFO": "/tests",
+      "HTTPS": "off",
+      "SCRIPT_NAME": "",
+      "CONTENT_LENGTH": "21",
+      "REMOTE_ADDR": "127.0.0.1",
+      "HTTP_HOST": "www.example.com",
+      "HTTP_ACCEPT": "application/json",
+      "CONTENT_TYPE": "application/json",
+      "HTTP_COOKIE": ""
+    }
   },
   "response": {
     "status": 204,


### PR DESCRIPTION
This better matches the structure of the Response data, allows for
better flexibility of usage going forward, and is necessary for properly 
discerning between different types of POSTs, such as "multipart/form-data"
vs "urlencoded".