### PR TITLE
Allow the application to load Rails configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- Allow the application to load Rails configuration.
+
 ## 8.0.0 (2024-03-19)
 
 - Include CGI/HTTP request Rack environment variables in the JSON dump.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,17 @@ $ bundle add rails-response-dumper --group=development,test
 ## Usage
 
 Add the `dumpers` directory to the root of your Rails application. In this
-directory, define classes that extend `ResponseDumper`. Each method that starts
-with `dump_` will generate a dump file in the `dumps` directory. Rails path
-methods are available.
+directory, create the file `dumpers_helper.rb` that loads the Rails
+environment.
+
+```ruby
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+```
+
+Next, define classes that extend `ResponseDumper`. Each method that starts with
+`dump_` will generate a dump file in the `dumps` directory. Rails path methods
+are available.
 
 ```ruby
 # dumpers/users_response_dumper.rb

--- a/bin/rails-response-dumper
+++ b/bin/rails-response-dumper
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-ENV['RAILS_ENV'] ||= 'test'
 require 'rails_response_dumper'
+require "#{Dir.pwd}/dumpers/dumpers_helper"
+require 'response_dumper'
 
 # Prevent database truncation if the environment is production.
 abort 'The Rails environment is running in production mode!' if Rails.env.production?

--- a/lib/rails_response_dumper.rb
+++ b/lib/rails_response_dumper.rb
@@ -2,4 +2,3 @@
 
 require_relative 'rails_response_dumper/option_parser'
 require_relative 'rails_response_dumper/runner'
-require_relative 'response_dumper'

--- a/lib/response_dumper.rb
+++ b/lib/response_dumper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "#{Dir.pwd}/config/environment"
 require 'rspec/mocks'
 
 class ResponseDumper

--- a/spec/test_apps/after_hook/dumpers/dumpers_helper.rb
+++ b/spec/test_apps/after_hook/dumpers/dumpers_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'

--- a/spec/test_apps/app/dumpers/dumpers_helper.rb
+++ b/spec/test_apps/app/dumpers/dumpers_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'

--- a/spec/test_apps/fail_app/dumpers/dumpers_helper.rb
+++ b/spec/test_apps/fail_app/dumpers/dumpers_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'


### PR DESCRIPTION
By allowing the application to load Rails configuration, the application can run other code necessary to setup the environment. For example, the application could enable coverage tools.