### PR TITLE
Pin `sqlite3` to `1.X`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem 'rubocop', group: [:development]
 gem 'rubocop-performance', group: [:development]
 gem 'rubocop-rails', group: [:development]
 gem 'rubocop-rspec', group: [:development]
-gem 'sqlite3', group: [:development]
+gem 'sqlite3', '< 2', group: [:development]
 
 gemspec


### PR DESCRIPTION
Currently there is an issue when attempting to use the latest version of `sqlite3` because it was pinned to version 1.4. An upstream fix has landed on main, but has not been released yet.

Error observed:
```
Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-arm64-darwin. Make sure all dependencies are added to Gemfile. (LoadError)
```

Upstream Fix: https://github.com/rails/rails/commit/e90cb82384b3709186ace6465543785fcd348f0a

Target Release (7.2): https://github.com/rails/rails/blob/7-2-stable/activerecord/CHANGELOG.md

Once 7.2 is released, `sqlite3` should be allowed to take the latest version.