### PR TITLE
Make compatible with Rack 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- Make compatible with Rack 3.1 and an omitted `rack.input` value.
+
 ## 9.0.0 (2024-03-26)
 
 - Allow the application to load Rails configuration.

--- a/lib/rails_response_dumper/runner.rb
+++ b/lib/rails_response_dumper/runner.rb
@@ -123,7 +123,7 @@ module RailsResponseDumper
             dump[:timestamp] = timestamp.iso8601 unless options[:exclude_timestamp]
 
             File.write("#{dumper_dir}/#{index}.json", JSON.pretty_generate(dump))
-            File.write("#{dumper_dir}/#{index}.request_body", request.body.string, mode: 'wb')
+            File.write("#{dumper_dir}/#{index}.request_body", request.body&.string, mode: 'wb')
             File.write("#{dumper_dir}/#{index}.response_body", response.body, mode: 'wb')
           end
 

--- a/spec/test_apps/app/snapshots/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots/hooks/hook/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots/root/index/0.json
+++ b/spec/test_apps/app/snapshots/root/index/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots/tests/multiple_requests/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_single_file/tests/multiple_requests/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots_two_files/root/index/0.json
+++ b/spec/test_apps/app/snapshots_two_files/root/index/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_two_files/tests/multiple_requests/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots_updated_dump/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/hooks/hook/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots_updated_dump/root/index/0.json
+++ b/spec/test_apps/app/snapshots_updated_dump/root/index/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots_without_response_headers/hooks/hook/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/hooks/hook/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots_without_response_headers/root/index/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/root/index/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",

--- a/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/0.json
+++ b/spec/test_apps/app/snapshots_without_response_headers/tests/multiple_requests/0.json
@@ -10,7 +10,6 @@
       "PATH_INFO": "/",
       "HTTPS": "off",
       "SCRIPT_NAME": "",
-      "CONTENT_LENGTH": "0",
       "REMOTE_ADDR": "127.0.0.1",
       "HTTP_HOST": "www.example.com",
       "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",


### PR DESCRIPTION
Starting with Rack 3.1, rack.input is optional which results in request.body being nil.

See:

https://github.com/rack/rack/blob/main/CHANGELOG.md

> SPEC Changes
>
> rack.input is now optional.