### PR TITLE
Change gemspec to use "add_dependency"

### DIFF
--- a/rails-response-dumper.gemspec
+++ b/rails-response-dumper.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_runtime_dependency 'rails', '>= 6.1', '< 8'
-  spec.add_runtime_dependency 'rspec-mocks', '~> 3.0'
+  spec.add_dependency 'rails', '>= 6.1', '< 8'
+  spec.add_dependency 'rspec-mocks', '~> 3.0'
 end


### PR DESCRIPTION
The "add_runtime_dependency" alias is soft-deprecated in favor of add_dependency. Fixes RuboCop offense:

```
 rails-response-dumper.gemspec:22:8: C: [Correctable] Gemspec/AddRuntimeDependency: Use add_dependency instead of add_runtime_dependency.
  spec.add_runtime_dependency 'rails', '>= 6.1', '< 8'
       ^^^^^^^^^^^^^^^^^^^^^^
rails-response-dumper.gemspec:23:8: C: [Correctable] Gemspec/AddRuntimeDependency: Use add_dependency instead of add_runtime_dependency.
  spec.add_runtime_dependency 'rspec-mocks', '~> 3.0'
       ^^^^^^^^^^^^^^^^^^^^^^
```