### PR TITLE
Remove sqlite3 pinned version from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem 'rubocop', group: [:development]
 gem 'rubocop-performance', group: [:development]
 gem 'rubocop-rails', group: [:development]
 gem 'rubocop-rspec', group: [:development]
-gem 'sqlite3', '< 3', group: [:development]
+gem 'sqlite3', group: [:development]
 
 gemspec


### PR DESCRIPTION
Since the release of Rails 7.2, the latest version of sqlite3 is supported.

Rails 7.2 was released August 10, 2024. See the announcement: https://rubyonrails.org/2024/8/10/Rails-7-2-0-has-been-released