### PR TITLE
Remove upper bound from dependencies

### DIFF
--- a/rails-response-dumper.gemspec
+++ b/rails-response-dumper.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'rails', '>= 6.1', '< 9'
-  spec.add_dependency 'rspec-mocks', '~> 3.0'
+  spec.add_dependency 'rails', '>= 6.1'
+  spec.add_dependency 'rspec-mocks', '>= 3.0'
 end


### PR DESCRIPTION
Allow projects using rails-response-dumpers to update Rails and other dependencies without being blocked by this as a dependency.