### PR TITLE
Add "cooldown" to dependabot.yml to reduce supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,21 @@ updates:
     schedule:
       interval: daily
     rebase-strategy: disabled
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
     rebase-strategy: disabled
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
     rebase-strategy: disabled
+    cooldown:
+      default-days: 5


### PR DESCRIPTION
A supply chain attack is a security threat by targeting third party packages in the package repository (or supply chain). If a third party package is compromised, a cooldown provides a window where maintainers and security experts can catch the problem before we integrate the compromised package into the project.

There have been some examples of this in the JavaScript ecosystem, for example:

- https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised

The docs on "cooldown" are available at:
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

> When cooldown is defined:
>
> 1. Dependabot checks for updates according to the defined schedule.interval
> settings.
>
> 2. Dependabot checks for any cooldown settings.
>
> 3. If a dependency’s new release falls within its cooldown period, Dependabot
> skips updating the version for that dependency.
>
> 4. Dependencies without a cooldown period, or those past their cooldown period,
> are updated to the latest version as per the configured versioning-strategy
> setting.
>
> 5. After a cooldown ends for a dependency, Dependabot resumes updating the
> dependency following the standard update strategy defined in dependabot.yml.

This means that packages that were released within the 5 day cooldown period will not update until that period has passed.